### PR TITLE
Iterator support (#10)

### DIFF
--- a/databases/backends/mysql.py
+++ b/databases/backends/mysql.py
@@ -159,7 +159,9 @@ class MySQLSession(DatabaseSession):
             await self.pool.release(self.conn)
             self.conn = None
 
-    async def iterate(self, query: ClauseElement) -> typing.AsyncIterator[Record]:
+    async def iterate(
+        self, query: ClauseElement
+    ) -> typing.AsyncGenerator[typing.Any, None]:
         query, args, result_columns = self._compile(query)
 
         conn = await self.acquire_connection()

--- a/databases/backends/postgres.py
+++ b/databases/backends/postgres.py
@@ -159,6 +159,16 @@ class PostgresSession(DatabaseSession):
             await self.pool.release(self.conn)
             self.conn = None
 
+    async def iterate(self, query: ClauseElement) -> typing.AsyncIterator[Record]:
+        query, args, result_columns = self._compile(query)
+
+        conn = await self.acquire_connection()
+        try:
+            async for row in conn.cursor(query, *args):
+                yield Record(row, result_columns, self.dialect)
+        finally:
+            await self.release_connection()
+
 
 class PostgresTransaction(DatabaseTransaction):
     def __init__(self, session: PostgresSession, force_rollback: bool = False):

--- a/databases/backends/postgres.py
+++ b/databases/backends/postgres.py
@@ -159,7 +159,9 @@ class PostgresSession(DatabaseSession):
             await self.pool.release(self.conn)
             self.conn = None
 
-    async def iterate(self, query: ClauseElement) -> typing.AsyncIterator[Record]:
+    async def iterate(
+        self, query: ClauseElement
+    ) -> typing.AsyncGenerator[typing.Any, None]:
         query, args, result_columns = self._compile(query)
 
         conn = await self.acquire_connection()

--- a/databases/core.py
+++ b/databases/core.py
@@ -155,6 +155,11 @@ class Database:
         with SessionContext(self.session_context, self.backend) as session:
             return await session.execute_many(query=query, values=values)
 
+    async def iterate(self, query: ClauseElement) -> typing.AsyncGenerator:
+        with SessionContext(self.session_context, self.backend) as session:
+            async for record in session.iterate(query):
+                yield record
+
     def transaction(self, force_rollback: bool = False) -> DatabaseTransaction:
         return TransactionContext(self.session_context, self.backend, force_rollback)
 

--- a/databases/core.py
+++ b/databases/core.py
@@ -155,7 +155,9 @@ class Database:
         with SessionContext(self.session_context, self.backend) as session:
             return await session.execute_many(query=query, values=values)
 
-    async def iterate(self, query: ClauseElement) -> typing.AsyncGenerator:
+    async def iterate(
+        self, query: ClauseElement
+    ) -> typing.AsyncGenerator[typing.Any, None]:
         with SessionContext(self.session_context, self.backend) as session:
             async for record in session.iterate(query):
                 yield record

--- a/databases/interfaces.py
+++ b/databases/interfaces.py
@@ -31,6 +31,9 @@ class DatabaseSession:
     def transaction(self, force_rollback: bool = False) -> "DatabaseTransaction":
         raise NotImplementedError()  # pragma: no cover
 
+    async def iterate(self, query: ClauseElement) -> typing.AsyncIterable[typing.Any]:
+        raise NotImplementedError()  # pragma: no cover
+
 
 class DatabaseTransaction:
     def __init__(self, force_rollback: bool = False):

--- a/databases/interfaces.py
+++ b/databases/interfaces.py
@@ -31,8 +31,13 @@ class DatabaseSession:
     def transaction(self, force_rollback: bool = False) -> "DatabaseTransaction":
         raise NotImplementedError()  # pragma: no cover
 
-    async def iterate(self, query: ClauseElement) -> typing.AsyncIterable[typing.Any]:
+    async def iterate(
+        self, query: ClauseElement
+    ) -> typing.AsyncGenerator[typing.Any, None]:
         raise NotImplementedError()  # pragma: no cover
+        # mypy needs async iterators to contain a `yield`
+        # https://github.com/python/mypy/issues/5385#issuecomment-407281656
+        yield True  # pragma: no cover
 
 
 class DatabaseTransaction:

--- a/tests/test_databases.py
+++ b/tests/test_databases.py
@@ -138,6 +138,19 @@ async def test_queries(database_url):
             assert result["text"] == "example1"
             assert result["completed"] == True
 
+            # iterate()
+            query = notes.select()
+            iterate_results = []
+            async for result in database.iterate(query=query):
+                iterate_results.append(result)
+            assert len(iterate_results) == 3
+            assert iterate_results[0]["text"] == "example1"
+            assert iterate_results[0]["completed"] == True
+            assert iterate_results[1]["text"] == "example2"
+            assert iterate_results[1]["completed"] == False
+            assert iterate_results[2]["text"] == "example3"
+            assert iterate_results[2]["completed"] == True
+
 
 @pytest.mark.parametrize("database_url", DATABASE_URLS)
 @async_adapter


### PR DESCRIPTION
Add `iterate()` to DatabaseSession and implementations, where the implementations return an async generator from the libraries' existing async-iterable cursors.