### PR TITLE
Ensure global connections are created on __init__.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.pyc
+test.db
 .coverage
 .pytest_cache/
 .mypy_cache/

--- a/databases/__init__.py
+++ b/databases/__init__.py
@@ -1,5 +1,5 @@
 from databases.core import Database, DatabaseURL
 
 
-__version__ = "0.1.3"
+__version__ = "0.1.4"
 __all__ = ["Database", "DatabaseURL"]


### PR DESCRIPTION
Resolves an integration issue with `@database.transaction()` that would end up with different context to the global rollback transaction when used with `database = (..., force_rollback=True)`