### PR TITLE
Tighten interface

### DIFF
--- a/databases/backends/mysql.py
+++ b/databases/backends/mysql.py
@@ -98,7 +98,7 @@ class MySQLConnection(ConnectionBackend):
         finally:
             await cursor.close()
 
-    async def fetch_one(self, query: ClauseElement) -> RowProxy:
+    async def fetch_one(self, query: ClauseElement) -> typing.Optional[RowProxy]:
         assert self._connection is not None, "Connection is not acquired"
         query, args, context = self._compile(query)
         cursor = await self._connection.cursor()

--- a/databases/backends/mysql.py
+++ b/databases/backends/mysql.py
@@ -83,7 +83,7 @@ class MySQLConnection(ConnectionBackend):
         await self._database._pool.release(self._connection)
         self._connection = None
 
-    async def fetch_all(self, query: ClauseElement) -> typing.List[RowProxy]:
+    async def fetch_all(self, query: ClauseElement) -> typing.List[typing.Mapping]:
         assert self._connection is not None, "Connection is not acquired"
         query, args, context = self._compile(query)
         cursor = await self._connection.cursor()
@@ -98,7 +98,7 @@ class MySQLConnection(ConnectionBackend):
         finally:
             await cursor.close()
 
-    async def fetch_one(self, query: ClauseElement) -> typing.Optional[RowProxy]:
+    async def fetch_one(self, query: ClauseElement) -> typing.Optional[typing.Mapping]:
         assert self._connection is not None, "Connection is not acquired"
         query, args, context = self._compile(query)
         cursor = await self._connection.cursor()

--- a/databases/backends/mysql.py
+++ b/databases/backends/mysql.py
@@ -105,6 +105,8 @@ class MySQLConnection(ConnectionBackend):
         try:
             await cursor.execute(query, args)
             row = await cursor.fetchone()
+            if row is None:
+                return None
             metadata = ResultMetaData(context, cursor.description)
             return RowProxy(metadata, row, metadata._processors, metadata._keymap)
         finally:

--- a/databases/backends/postgres.py
+++ b/databases/backends/postgres.py
@@ -121,6 +121,8 @@ class PostgresConnection(ConnectionBackend):
         assert self._connection is not None, "Connection is not acquired"
         query, args, result_columns = self._compile(query)
         row = await self._connection.fetchrow(query, *args)
+        if row is None:
+            return None
         return Record(row, result_columns, self._dialect)
 
     async def execute(self, query: ClauseElement, values: dict = None) -> typing.Any:

--- a/databases/backends/postgres.py
+++ b/databases/backends/postgres.py
@@ -111,13 +111,13 @@ class PostgresConnection(ConnectionBackend):
         self._connection = await self._database._pool.release(self._connection)
         self._connection = None
 
-    async def fetch_all(self, query: ClauseElement) -> typing.List[Record]:
+    async def fetch_all(self, query: ClauseElement) -> typing.List[typing.Mapping]:
         assert self._connection is not None, "Connection is not acquired"
         query, args, result_columns = self._compile(query)
         rows = await self._connection.fetch(query, *args)
         return [Record(row, result_columns, self._dialect) for row in rows]
 
-    async def fetch_one(self, query: ClauseElement) -> typing.Optional[Record]:
+    async def fetch_one(self, query: ClauseElement) -> typing.Optional[typing.Mapping]:
         assert self._connection is not None, "Connection is not acquired"
         query, args, result_columns = self._compile(query)
         row = await self._connection.fetchrow(query, *args)

--- a/databases/backends/sqlite.py
+++ b/databases/backends/sqlite.py
@@ -79,7 +79,7 @@ class SQLiteConnection(ConnectionBackend):
         await self._pool.release(self._connection)
         self._connection = None
 
-    async def fetch_all(self, query: ClauseElement) -> typing.List[RowProxy]:
+    async def fetch_all(self, query: ClauseElement) -> typing.List[typing.Mapping]:
         assert self._connection is not None, "Connection is not acquired"
         query, args, context = self._compile(query)
 
@@ -91,7 +91,7 @@ class SQLiteConnection(ConnectionBackend):
                 for row in rows
             ]
 
-    async def fetch_one(self, query: ClauseElement) -> typing.Optional[RowProxy]:
+    async def fetch_one(self, query: ClauseElement) -> typing.Optional[typing.Mapping]:
         assert self._connection is not None, "Connection is not acquired"
         query, args, context = self._compile(query)
 

--- a/databases/backends/sqlite.py
+++ b/databases/backends/sqlite.py
@@ -91,7 +91,7 @@ class SQLiteConnection(ConnectionBackend):
                 for row in rows
             ]
 
-    async def fetch_one(self, query: ClauseElement) -> RowProxy:
+    async def fetch_one(self, query: ClauseElement) -> typing.Optional[RowProxy]:
         assert self._connection is not None, "Connection is not acquired"
         query, args, context = self._compile(query)
 

--- a/databases/backends/sqlite.py
+++ b/databases/backends/sqlite.py
@@ -97,6 +97,8 @@ class SQLiteConnection(ConnectionBackend):
 
         async with self._connection.execute(query, args) as cursor:
             row = await cursor.fetchone()
+            if row is None:
+                return None
             metadata = ResultMetaData(context, cursor.description)
             return RowProxy(metadata, row, metadata._processors, metadata._keymap)
 

--- a/databases/backends/sqlite.py
+++ b/databases/backends/sqlite.py
@@ -102,7 +102,7 @@ class SQLiteConnection(ConnectionBackend):
             metadata = ResultMetaData(context, cursor.description)
             return RowProxy(metadata, row, metadata._processors, metadata._keymap)
 
-    async def execute(self, query: ClauseElement, values: dict = None) -> None:
+    async def execute(self, query: ClauseElement, values: dict = None) -> typing.Any:
         assert self._connection is not None, "Connection is not acquired"
         if values is not None:
             query = query.values(values)

--- a/databases/interfaces.py
+++ b/databases/interfaces.py
@@ -27,7 +27,7 @@ class ConnectionBackend:
     async def fetch_one(self, query: ClauseElement) -> typing.Optional[typing.Mapping]:
         raise NotImplementedError()  # pragma: no cover
 
-    async def execute(self, query: ClauseElement, values: dict = None) -> None:
+    async def execute(self, query: ClauseElement, values: dict = None) -> typing.Any:
         raise NotImplementedError()  # pragma: no cover
 
     async def execute_many(self, query: ClauseElement, values: list) -> None:

--- a/databases/interfaces.py
+++ b/databases/interfaces.py
@@ -1,6 +1,5 @@
 import typing
 
-from sqlalchemy.engine import RowProxy
 from sqlalchemy.sql import ClauseElement
 
 
@@ -22,10 +21,10 @@ class ConnectionBackend:
     async def release(self) -> None:
         raise NotImplementedError()  # pragma: no cover
 
-    async def fetch_all(self, query: ClauseElement) -> typing.List[RowProxy]:
+    async def fetch_all(self, query: ClauseElement) -> typing.List[typing.Mapping]:
         raise NotImplementedError()  # pragma: no cover
 
-    async def fetch_one(self, query: ClauseElement) -> RowProxy:
+    async def fetch_one(self, query: ClauseElement) -> typing.Optional[typing.Mapping]:
         raise NotImplementedError()  # pragma: no cover
 
     async def execute(self, query: ClauseElement, values: dict = None) -> None:
@@ -36,7 +35,7 @@ class ConnectionBackend:
 
     async def iterate(
         self, query: ClauseElement
-    ) -> typing.AsyncGenerator[RowProxy, None]:
+    ) -> typing.AsyncGenerator[typing.Mapping, None]:
         raise NotImplementedError()  # pragma: no cover
         # mypy needs async iterators to contain a `yield`
         # https://github.com/python/mypy/issues/5385#issuecomment-407281656

--- a/scripts/lint
+++ b/scripts/lint
@@ -10,3 +10,4 @@ set -x
 ${PREFIX}autoflake --in-place --recursive databases tests
 ${PREFIX}black databases tests
 ${PREFIX}isort --multi-line=3 --trailing-comma --force-grid-wrap=0 --combine-as --line-width 88 --recursive --apply databases tests
+${PREFIX}mypy databases --ignore-missing-imports --disallow-untyped-defs

--- a/tests/test_databases.py
+++ b/tests/test_databases.py
@@ -153,6 +153,46 @@ async def test_queries(database_url):
 
 @pytest.mark.parametrize("database_url", DATABASE_URLS)
 @async_adapter
+async def test_results_support_mapping_interface(database_url):
+    """
+    Casting results to a dict should work, since the interface defines them
+    as supporting the mapping interface.
+    """
+    async with Database(database_url) as database:
+        async with database.transaction(force_rollback=True):
+            # execute()
+            query = notes.insert()
+            values = {"text": "example1", "completed": True}
+            await database.execute(query, values)
+
+            # fetch_all()
+            query = notes.select()
+            results = await database.fetch_all(query=query)
+            results_dict = dict(results[0])
+
+            assert len(results_dict) == 3
+            assert isinstance(results_dict["id"], int)
+            assert results_dict["text"] == "example1"
+            assert results_dict["completed"] == True
+
+
+@pytest.mark.parametrize("database_url", DATABASE_URLS)
+@async_adapter
+async def test_fetch_one_returning_no_results(database_url):
+    """
+    fetch_one should return `None` when no results match.
+    """
+    async with Database(database_url) as database:
+        async with database.transaction(force_rollback=True):
+            # fetch_all()
+            query = notes.select()
+            result = await database.fetch_one(query=query)
+            assert result is None
+
+
+
+@pytest.mark.parametrize("database_url", DATABASE_URLS)
+@async_adapter
 async def test_execute_return_val(database_url):
     """
     Test using return value from `execute()` to get an inserted primary key.

--- a/tests/test_databases.py
+++ b/tests/test_databases.py
@@ -190,7 +190,6 @@ async def test_fetch_one_returning_no_results(database_url):
             assert result is None
 
 
-
 @pytest.mark.parametrize("database_url", DATABASE_URLS)
 @async_adapter
 async def test_execute_return_val(database_url):

--- a/tests/test_databases.py
+++ b/tests/test_databases.py
@@ -168,14 +168,14 @@ async def test_results_support_mapping_interface(database_url):
             # fetch_all()
             query = notes.select()
             results = await database.fetch_all(query=query)
-            results_dict = dict(results[0])
+            results_as_dicts = [dict(item) for item in results]
 
-            assert len(results) == 3
-            assert len(results_dict) == 3
+            assert len(results[0]) == 3
+            assert len(results_as_dicts[0]) == 3
 
-            assert isinstance(results_dict["id"], int)
-            assert results_dict["text"] == "example1"
-            assert results_dict["completed"] == True
+            assert isinstance(results_as_dicts[0]["id"], int)
+            assert results_as_dicts[0]["text"] == "example1"
+            assert results_as_dicts[0]["completed"] == True
 
 
 @pytest.mark.parametrize("database_url", DATABASE_URLS)

--- a/tests/test_databases.py
+++ b/tests/test_databases.py
@@ -170,7 +170,9 @@ async def test_results_support_mapping_interface(database_url):
             results = await database.fetch_all(query=query)
             results_dict = dict(results[0])
 
+            assert len(results) == 3
             assert len(results_dict) == 3
+
             assert isinstance(results_dict["id"], int)
             assert results_dict["text"] == "example1"
             assert results_dict["completed"] == True


### PR DESCRIPTION
* `fetch_all` returns `typing.List[typing.Mapping]`
* `fetch_one` returns `typing.Optional[typing.Mapping]`
* `execute` returns `typing.Any` (Last cursor id. Required to determine pk of inserts.)

Also fix implementation of `fetch_one` to handle `None` case correctly.