### PR TITLE
Fixes #53 Reformat debug log for queries

### DIFF
--- a/databases/backends/mysql.py
+++ b/databases/backends/mysql.py
@@ -169,7 +169,7 @@ class MySQLConnection(ConnectionBackend):
             compiled._textual_ordered_columns,
         )
 
-        logger.debug(compiled.string, args)
+        logger.debug("Query: %s\nArgs: %s", compiled.string, args)
         return compiled.string, args, CompilationContext(execution_context)
 
 

--- a/databases/backends/postgres.py
+++ b/databases/backends/postgres.py
@@ -168,7 +168,7 @@ class PostgresConnection(ConnectionBackend):
             for key, val in compiled_params
         ]
 
-        logger.debug(compiled_query, args)
+        logger.debug("Query: %s\nArgs: %s", compiled_query, args)
         return compiled_query, args, compiled._result_columns
 
 

--- a/databases/backends/sqlite.py
+++ b/databases/backends/sqlite.py
@@ -150,7 +150,7 @@ class SQLiteConnection(ConnectionBackend):
             compiled._textual_ordered_columns,
         )
 
-        logger.debug(compiled.string, args)
+        logger.debug("Query: %s\nArgs: %s", compiled.string, args)
         return compiled.string, args, CompilationContext(execution_context)
 
 


### PR DESCRIPTION
It modifies the format of debug log entries for queries to fix #53. We could change the string template if it isn't appropriate.