### PR TITLE
fix issue with duplicate column names

### DIFF
--- a/databases/__init__.py
+++ b/databases/__init__.py
@@ -1,5 +1,5 @@
 from databases.core import Database, DatabaseURL
 
 
-__version__ = "0.1.8"
+__version__ = "0.1.9"
 __all__ = ["Database", "DatabaseURL"]

--- a/databases/backends/postgres.py
+++ b/databases/backends/postgres.py
@@ -73,9 +73,16 @@ class Record(Mapping):
             column_name: (idx, datatype)
             for idx, (column_name, _, _, datatype) in enumerate(self._result_columns)
         }
+        self._column_map_full = {
+            str(column[0]): (idx, datatype)
+            for idx, (_, _, column, datatype) in enumerate(self._result_columns)
+        }
 
-    def __getitem__(self, key: str) -> typing.Any:
-        idx, datatype = self._column_map[key]
+    def __getitem__(self, key) -> typing.Any:
+        if type(key) is str:
+            idx, datatype = self._column_map[key]
+        else:
+            idx, datatype = self._column_map_full[str(key)]
         raw = self._row[idx]
         try:
             processor = _result_processors[datatype]

--- a/databases/backends/postgres.py
+++ b/databases/backends/postgres.py
@@ -79,7 +79,7 @@ class Record(Mapping):
             for idx, (_, _, column, datatype) in enumerate(self._result_columns)
         }
 
-    def __getitem__(self, key) -> typing.Any:
+    def __getitem__(self, key: typing.Any) -> typing.Any:
         if type(key) is Column:
             idx, datatype = self._column_map_full[str(key)]
         else:

--- a/databases/backends/postgres.py
+++ b/databases/backends/postgres.py
@@ -6,6 +6,7 @@ import asyncpg
 from sqlalchemy.dialects.postgresql import pypostgresql
 from sqlalchemy.engine.interfaces import Dialect
 from sqlalchemy.sql import ClauseElement
+from sqlalchemy.sql.schema import Column
 
 from databases.core import DatabaseURL
 from databases.interfaces import ConnectionBackend, DatabaseBackend, TransactionBackend
@@ -79,10 +80,10 @@ class Record(Mapping):
         }
 
     def __getitem__(self, key) -> typing.Any:
-        if type(key) is str:
-            idx, datatype = self._column_map[key]
-        else:
+        if type(key) is Column:
             idx, datatype = self._column_map_full[str(key)]
+        else:
+            idx, datatype = self._column_map[key]
         raw = self._row[idx]
         try:
             processor = _result_processors[datatype]

--- a/tests/test_databases.py
+++ b/tests/test_databases.py
@@ -195,7 +195,7 @@ async def test_results_support_column_reference(database_url):
             values = {"title": "Hello, world Article", "published": now}
             await database.execute(query, values)
 
-            query = custom_date.insert()            
+            query = custom_date.insert()
             values = {"title": "Hello, world Custom", "published": today}
             await database.execute(query, values)
 

--- a/tests/test_databases.py
+++ b/tests/test_databases.py
@@ -180,6 +180,37 @@ async def test_results_support_mapping_interface(database_url):
 
 @pytest.mark.parametrize("database_url", DATABASE_URLS)
 @async_adapter
+async def test_results_support_column_reference(database_url):
+    """
+    Casting results to a dict should work, since the interface defines them
+    as supporting the mapping interface.
+    """
+    async with Database(database_url) as database:
+        async with database.transaction(force_rollback=True):
+            now = datetime.datetime.now().replace(microsecond=0)
+            today = datetime.date.today()
+
+            # execute()
+            query = articles.insert()
+            values = {"title": "Hello, world Article", "published": now}
+            await database.execute(query, values)
+
+            query = custom_date.insert()            
+            values = {"title": "Hello, world Custom", "published": today}
+            await database.execute(query, values)
+
+            # fetch_all()
+            query = sqlalchemy.select([articles, custom_date])
+            results = await database.fetch_all(query=query)
+            assert len(results) == 1
+            assert results[0][articles.c.title] == "Hello, world Article"
+            assert results[0][articles.c.published] == now
+            assert results[0][custom_date.c.title] == "Hello, world Custom"
+            assert results[0][custom_date.c.published] == today
+
+
+@pytest.mark.parametrize("database_url", DATABASE_URLS)
+@async_adapter
 async def test_fetch_one_returning_no_results(database_url):
     """
     fetch_one should return `None` when no results match.


### PR DESCRIPTION
Hi I'm creating a pull request to allow developers to retrieve data from row using row[table.c.column_name] instead of row['column_name'], while this helps keeping the code mode clean it also fixes issues that I was having when executing selects that were returning duplicated columns: 

`select table1.code, table1.name, table2.code from table1, table2 where table1.code = table2.some_other_code`