### PR TITLE
Support for explicit connection management #9

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,27 @@ await database.disconnect()
 Connections are managed as task-local state, with driver implementations
 transparently using connection pooling behind the scenes.
 
+## Connections
+
+Connections are managed by async context blocks:
+
+```python
+async with database.connection():
+    ...
+```
+
+For a lower-level transaction API:
+
+```python
+connection = await database.connection()
+try:
+    ...
+except:
+    ...
+finally:
+    connection.release()
+```
+
 ## Transactions
 
 Transactions are managed by async context blocks:

--- a/databases/core.py
+++ b/databases/core.py
@@ -156,6 +156,12 @@ class Connection:
             if self._connection_counter == 0:
                 await self._connection.release()
 
+    def __await__(self) -> typing.Generator[typing.Any, None, "Connection"]:
+        return self.__aenter__().__await__()
+
+    async def release(self) -> None:
+        await self.__aexit__()
+
     async def fetch_all(self, query: ClauseElement) -> typing.Any:
         return await self._connection.fetch_all(query=query)
 

--- a/databases/core.py
+++ b/databases/core.py
@@ -150,17 +150,17 @@ class Connection:
         exc_value: BaseException = None,
         traceback: TracebackType = None,
     ) -> None:
-        async with self._connection_lock:
-            assert self._connection is not None
-            self._connection_counter -= 1
-            if self._connection_counter == 0:
-                await self._connection.release()
+        await self.release()
 
     def __await__(self) -> typing.Generator[typing.Any, None, "Connection"]:
         return self.__aenter__().__await__()
 
     async def release(self) -> None:
-        await self.__aexit__()
+        async with self._connection_lock:
+            assert self._connection is not None
+            self._connection_counter -= 1
+            if self._connection_counter == 0:
+                await self._connection.release()
 
     async def fetch_all(self, query: ClauseElement) -> typing.Any:
         return await self._connection.fetch_all(query=query)

--- a/tests/test_databases.py
+++ b/tests/test_databases.py
@@ -643,3 +643,47 @@ async def test_database_url_interface(database_url):
     async with Database(database_url) as database:
         assert isinstance(database.url, DatabaseURL)
         assert database.url == database_url
+
+
+@pytest.mark.parametrize("database_url", DATABASE_URLS)
+@async_adapter
+async def test_connection_acquire_and_release(database_url):
+    """
+    Test for the `connection = await database.connection() ... connection.release()`
+    """
+    # Get the database back-end via the context manager
+    async with Database(database_url) as database:
+        # Part 1: Context manager
+        # Get the connection via the context manager
+        async with database.connection() as connection_1:
+            # Check the connection in the context manager
+            assert connection_1 is database._connection_context.get()
+            # Check the number of connection
+            assert connection_1._connection_counter == 1
+            # Check the connection works
+            data = await connection_1.fetch_all(sqlalchemy.text("select * from notes"))
+            assert data == []
+        # Check the connection is released
+        assert connection_1._connection._connection is None
+        # Check the number of connection
+        assert connection_1._connection_counter == 0
+
+        # Part 2: explicit/function call
+        # Get the connection explicitly
+        # (but via the context manager behind the scene)
+        connection_2 = await database.connection()
+        # Check the connection in the context manager
+        assert connection_2 is database._connection_context.get()
+        # Check the number of connection
+        assert connection_2._connection_counter == 1
+        # Check the connection works
+        data = await connection_2.fetch_all(sqlalchemy.text("select * from notes"))
+        assert data == []
+        # Release the connection explicitly
+        await connection_2.release()
+        # Check the connection is released
+        assert connection_2._connection._connection is None
+        # Check the number of connection
+        assert connection_2._connection_counter == 0
+
+        assert connection_1 is connection_2


### PR DESCRIPTION
Support for this:

```connection = await database.connection() ... connection.release()```