### PR TITLE
Add tests showing error on bulk update with non-raw query

### DIFF
--- a/tests/test_databases.py
+++ b/tests/test_databases.py
@@ -155,6 +155,26 @@ async def test_queries(database_url):
             assert iterate_results[2]["text"] == "example3"
             assert iterate_results[2]["completed"] == True
 
+            # update
+            query = (notes.update()
+                     .values(completed=sqlalchemy.sql.bindparam('completed'))
+                     .where(notes.c.text == sqlalchemy.sql.bindparam('_text')))
+            values = [
+                {'_text': 'example1', 'completed': False},
+                {'_text': 'example2', 'completed': True},
+            ]
+            results = await database.execute_many(query, values)
+
+            query = notes.select().order_by(notes.c.id.asc())
+            results = await database.fetch_all(query=query)
+            assert len(results) == 3
+            assert results[0]["text"] == "example1"
+            assert results[0]["completed"] == False
+            assert results[1]["text"] == "example2"
+            assert results[1]["completed"] == True
+            assert results[2]["text"] == "example3"
+            assert results[2]["completed"] == True
+
 
 @pytest.mark.parametrize("database_url", DATABASE_URLS)
 @async_adapter
@@ -205,6 +225,24 @@ async def test_queries_raw(database_url):
             assert iterate_results[1]["completed"] == False
             assert iterate_results[2]["text"] == "example3"
             assert iterate_results[2]["completed"] == True
+
+            # update
+            query = "UPDATE notes SET completed = :completed WHERE text = :_text"
+            values = [
+                {'_text': 'example1', 'completed': False},
+                {'_text': 'example2', 'completed': True},
+            ]
+            results = await database.execute_many(query, values)
+
+            query = "SELECT * FROM notes ORDER BY id ASC"
+            results = await database.fetch_all(query=query)
+            assert len(results) == 3
+            assert results[0]["text"] == "example1"
+            assert results[0]["completed"] == False
+            assert results[1]["text"] == "example2"
+            assert results[1]["completed"] == True
+            assert results[2]["text"] == "example3"
+            assert results[2]["completed"] == True
 
 
 @pytest.mark.parametrize("database_url", DATABASE_URLS)


### PR DESCRIPTION
I've been battling with an issue today where I was unable to do a bulk update on a table using the non-raw query builder syntax. These tests should showcase that the issue has something to do with how values are handled in `databases.core.Database._build_query`. In particular it seems to be impossible to use `bindparam`s in where clauses with the current functionality. The assertions in `test_queries` fail, but the assertions in `test_raw_queries` pass even though they ought to map to the same SQL.