### PR TITLE
Add PgSQL record access by attribute

### DIFF
--- a/databases/backends/postgres.py
+++ b/databases/backends/postgres.py
@@ -119,6 +119,12 @@ class Record(Mapping):
     def __len__(self) -> int:
         return len(self._column_map)
 
+    def __getattr__(self, name: typing.Any) -> typing.Any:
+        try:
+            return self[name]
+        except KeyError as e:
+            raise AttributeError(e.args[0])
+
 
 class PostgresConnection(ConnectionBackend):
     def __init__(self, database: PostgresBackend, dialect: Dialect):


### PR DESCRIPTION
It's fairly usual to access a record's content vy its attributed: `myrecord.id`. While this works with the SQLite backend, it's not possible now with the PostgreSQL one. This fix replicates what SA does on a RowProxy.

Signed-off-by: Sylvain Hellegouarch <sh@defuze.org>