### PR TITLE
Add test for #81 - asyncio flow branching

### DIFF
--- a/tests/test_databases.py
+++ b/tests/test_databases.py
@@ -692,6 +692,20 @@ async def test_queries_with_expose_backend_connection(database_url):
 
 @pytest.mark.parametrize("database_url", DATABASE_URLS)
 @async_adapter
+async def test_asyncio_flow_branching(database_url):
+    async with Database(database_url, force_rollback=True) as database:
+        async def db_lookup():
+            if str(database_url).startswith("postgresql"):
+                await database.fetch_one("SELECT pg_sleep(1)")
+
+        await asyncio.gather(
+            db_lookup(),
+            db_lookup(),
+        )
+
+
+@pytest.mark.parametrize("database_url", DATABASE_URLS)
+@async_adapter
 async def test_database_url_interface(database_url):
     """
     Test that Database instances expose a `.url` attribute.


### PR DESCRIPTION
Added a failing test that raises `asyncpg.exceptions._base.InterfaceError`

```python
======================================================= FAILURES =======================================================
_______________________ test_asyncio_flow_branching[postgresql://postgres@localhost:5432/testdb] _______________________

database_url = 'postgresql://postgres@localhost:5432/testdb'

    @pytest.mark.parametrize("database_url", DATABASE_URLS)
    @async_adapter
    async def test_asyncio_flow_branching(database_url):
        async with Database(database_url, force_rollback=True) as database:
            async def db_lookup():
                if str(database_url).startswith("postgresql"):
                    await database.fetch_one("SELECT pg_sleep(1)")

            await asyncio.gather(
                db_lookup(),
>               db_lookup(),
            )

tests/test_databases.py:704:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

    async def db_lookup():
        if str(database_url).startswith("postgresql"):
>           await database.fetch_one("SELECT pg_sleep(1)")

tests/test_databases.py:700:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <databases.core.Database object at 0x1074ed550>, query = 'SELECT pg_sleep(1)', values = None

    async def fetch_one(
        self, query: typing.Union[ClauseElement, str], values: dict = None
    ) -> typing.Optional[typing.Mapping]:
        async with self.connection() as connection:
>           return await connection.fetch_one(query, values)

databases/core.py:101:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <databases.core.Connection object at 0x1074ed6a0>, query = 'SELECT pg_sleep(1)', values = None

    async def fetch_one(
        self, query: typing.Union[ClauseElement, str], values: dict = None
    ) -> typing.Optional[typing.Mapping]:
>       return await self._connection.fetch_one(self._build_query(query, values))

databases/core.py:184:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <databases.backends.postgres.PostgresConnection object at 0x1074ed710>, query = 'SELECT pg_sleep(1)'

    async def fetch_one(self, query: ClauseElement) -> typing.Optional[typing.Mapping]:
        assert self._connection is not None, "Connection is not acquired"
        query, args, result_columns = self._compile(query)
>       row = await self._connection.fetchrow(query, *args)

databases/backends/postgres.py:143:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <asyncpg.connection.Connection object at 0x1074e1120>, query = 'SELECT pg_sleep(1)', timeout = None, args = ()

    async def fetchrow(self, query, *args, timeout=None):
        """Run a query and return the first row.

        :param str query: Query text
        :param args: Query arguments
        :param float timeout: Optional timeout value in seconds.

        :return: The first row as a :class:`Record` instance, or None if
                 no records were returned by the query.
        """
        self._check_open()
>       data = await self._execute(query, args, 1, timeout)

../../../.local/share/virtualenvs/databases-nXlIYhYa/lib/python3.7/site-packages/asyncpg/connection.py:455:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <asyncpg.connection.Connection object at 0x1074e1120>, query = 'SELECT pg_sleep(1)', args = (), limit = 1
timeout = None, return_status = False

    async def _execute(self, query, args, limit, timeout, return_status=False):
>       with self._stmt_exclusive_section:

../../../.local/share/virtualenvs/databases-nXlIYhYa/lib/python3.7/site-packages/asyncpg/connection.py:1412:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <asyncpg.connection._Atomic object at 0x1074cbfd8>

    def __enter__(self):
        if self._acquired:
            raise exceptions.InterfaceError(
>               'cannot perform operation: another operation is in progress')
E           asyncpg.exceptions._base.InterfaceError: cannot perform operation: another operation is in progress

../../../.local/share/virtualenvs/databases-nXlIYhYa/lib/python3.7/site-packages/asyncpg/connection.py:1847: InterfaceError

During handling of the above exception, another exception occurred:

database_url = 'postgresql://postgres@localhost:5432/testdb'

    @pytest.mark.parametrize("database_url", DATABASE_URLS)
    @async_adapter
    async def test_asyncio_flow_branching(database_url):
        async with Database(database_url, force_rollback=True) as database:
            async def db_lookup():
                if str(database_url).startswith("postgresql"):
                    await database.fetch_one("SELECT pg_sleep(1)")

            await asyncio.gather(
                db_lookup(),
>               db_lookup(),
            )

tests/test_databases.py:704:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
databases/core.py:89: in __aexit__
    await self.disconnect()
databases/core.py:74: in disconnect
    await self._global_transaction.__aexit__()
databases/core.py:256: in __aexit__
    await self.rollback()
databases/core.py:297: in rollback
    await self._transaction.rollback()
databases/backends/postgres.py:215: in rollback
    await self._transaction.rollback()
../../../.local/share/virtualenvs/databases-nXlIYhYa/lib/python3.7/site-packages/asyncpg/transaction.py:219: in rollback
    await self.__rollback()
../../../.local/share/virtualenvs/databases-nXlIYhYa/lib/python3.7/site-packages/asyncpg/transaction.py:198: in __rollback
    await self._connection.execute(query)
../../../.local/share/virtualenvs/databases-nXlIYhYa/lib/python3.7/site-packages/asyncpg/connection.py:273: in execute
    return await self._protocol.query(query, timeout)
asyncpg/protocol/protocol.pyx:301: in query
    ???
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

>   ???
E   asyncpg.exceptions._base.InterfaceError: cannot perform operation: another operation is in progress

asyncpg/protocol/protocol.pyx:659: InterfaceError
```
