### PR TITLE
Test case for iterating outside a transaction for #102

### DIFF
--- a/tests/test_databases.py
+++ b/tests/test_databases.py
@@ -703,16 +703,49 @@ async def test_database_url_interface(database_url):
 
 @pytest.mark.parametrize("database_url", DATABASE_URLS)
 @async_adapter
-async def test_iterate_outside_transaction(database_url):
+async def test_iterate_outside_transaction_with_values(database_url):
     """
     Ensure `iterate()` works even without a transaction on all drivers.
-
     The asyncpg driver relies on server-side cursors without hold
     for iteration, which requires a transaction to be created.
     This is mentionned in both their documentation and their test suite.
     """
+
+    database_url = DatabaseURL(database_url)
+    if database_url.dialect == "mysql":
+        pytest.skip("MySQL does not support `FROM (VALUES ...)` (F641)")
+
     async with Database(database_url) as database:
         query = "SELECT * FROM (VALUES (1), (2), (3), (4), (5)) as t"
+        iterate_results = []
+
+        async for result in database.iterate(query=query):
+            iterate_results.append(result)
+
+        assert len(iterate_results) == 5
+        assert iterate_results == [(1,), (2,), (3,), (4,), (5,)]
+
+
+@pytest.mark.parametrize("database_url", DATABASE_URLS)
+@async_adapter
+async def test_iterate_outside_transaction_with_temp_table(database_url):
+    """
+    Same as test_iterate_outside_transaction_with_values but uses a
+    temporary table instead of a list of values.
+    """
+
+    database_url = DatabaseURL(database_url)
+    if database_url.dialect == "sqlite":
+        pytest.skip("SQLite interface does not work with temporary tables.")
+
+    async with Database(database_url) as database:
+        query = "CREATE TEMPORARY TABLE no_transac(num INTEGER)"
+        await database.execute(query)
+
+        query = "INSERT INTO no_transac(num) VALUES (1), (2), (3), (4), (5)"
+        await database.execute(query)
+
+        query = "SELECT * FROM no_transac"
         iterate_results = []
 
         async for result in database.iterate(query=query):


### PR DESCRIPTION
The asyncpg driver relies on server-side cursors without hold for iteration, so they don't work unless the query is wrapped within a transaction. This is mentionned in both [their documentation][1] and their [test suite][2].

This seems to be the only driver with that quirk, so this test case ensures that databases uniformises that behavior across all supported engines.

[1]: https://magicstack.github.io/asyncpg/current/api/index.html#cursors
[2]: https://github.com/MagicStack/asyncpg/blob/2d76f50dccf35cf2f1d70b41ebd6198d2dfff8d7/tests/test_cursor.py#L31-L49