### PR TITLE
use native decimal (numeric) type

### DIFF
--- a/databases/backends/mysql.py
+++ b/databases/backends/mysql.py
@@ -23,6 +23,7 @@ class MySQLBackend(DatabaseBackend):
         self._database_url = DatabaseURL(database_url)
         self._options = options
         self._dialect = pymysql.dialect(paramstyle="pyformat")
+        self._dialect.supports_native_decimal = True
         self._pool = None
 
     def _get_connection_kwargs(self) -> dict:

--- a/databases/backends/postgres.py
+++ b/databases/backends/postgres.py
@@ -36,6 +36,7 @@ class PostgresBackend(DatabaseBackend):
         dialect._backslash_escapes = False
         dialect.supports_sane_multi_rowcount = True  # psycopg 2.0.9+
         dialect._has_native_hstore = True
+        dialect.supports_native_decimal = True
 
         return dialect
 

--- a/databases/backends/sqlite.py
+++ b/databases/backends/sqlite.py
@@ -22,6 +22,8 @@ class SQLiteBackend(DatabaseBackend):
         self._database_url = DatabaseURL(database_url)
         self._options = options
         self._dialect = pysqlite.dialect(paramstyle="qmark")
+        # aiosqlite does not support decimals
+        self._dialect.supports_native_decimal = False
         self._pool = SQLitePool(self._database_url, **self._options)
 
     async def connect(self) -> None:


### PR DESCRIPTION
Enables Postgresql and MySQL native support for Decimal (NUMERIC) type, which improves precision for decimals.

Closes #113