### PR TITLE
Fix record iteration

### DIFF
--- a/databases/backends/postgres.py
+++ b/databases/backends/postgres.py
@@ -115,10 +115,10 @@ class Record(Mapping):
         return raw
 
     def __iter__(self) -> typing.Iterator:
-        return iter(self._column_map)
+        return iter(self._row.keys())
 
     def __len__(self) -> int:
-        return len(self._column_map)
+        return len(self._row)
 
 
 class PostgresConnection(ConnectionBackend):

--- a/tests/test_databases.py
+++ b/tests/test_databases.py
@@ -809,8 +809,7 @@ async def test_iterate_outside_transaction_with_temp_table(database_url):
 @async_adapter
 async def test_column_names(database_url, select_query):
     """
-    Test that the basic `execute()`, `execute_many()`, `fetch_all()``, and
-    `fetch_one()` interfaces are all supported (using SQLAlchemy core).
+    Test that column names are exposed correctly through `.keys()` on each row.
     """
     async with Database(database_url) as database:
         async with database.transaction(force_rollback=True):

--- a/tests/test_importer.py
+++ b/tests/test_importer.py
@@ -7,21 +7,21 @@ def test_invalid_format():
     with pytest.raises(ImportFromStringError) as exc:
         import_from_string("example:")
     expected = 'Import string "example:" must be in format "<module>:<attribute>".'
-    assert expected in str(exc)
+    assert exc.match(expected)
 
 
 def test_invalid_module():
     with pytest.raises(ImportFromStringError) as exc:
         import_from_string("module_does_not_exist:myattr")
     expected = 'Could not import module "module_does_not_exist".'
-    assert expected in str(exc)
+    assert exc.match(expected)
 
 
 def test_invalid_attr():
     with pytest.raises(ImportFromStringError) as exc:
         import_from_string("tempfile:attr_does_not_exist")
     expected = 'Attribute "attr_does_not_exist" not found in module "tempfile".'
-    assert expected in str(exc)
+    assert exc.match(expected)
 
 
 def test_internal_import_error():


### PR DESCRIPTION
Hi again,
I ran into an issue with row columns (`row.keys()` would be empty) from a raw (text) query ('SELECT * FROM ...'). It seems to me it can be fixed by this MR - please have a look. As a side effect I had to adapt some tests for pytest 5, it works with 4.6 as well though.
Cheers
Jakub