### PR TITLE
Fix fetch_val for raw queries in Postgres backend

### DIFF
--- a/databases/backends/postgres.py
+++ b/databases/backends/postgres.py
@@ -96,7 +96,7 @@ class Record(Mapping):
 
     def __getitem__(self, key: typing.Any) -> typing.Any:
         if len(self._column_map) == 0:  # raw query
-            return self._row[tuple(self._row.keys()).index(key)]
+            return self._row[key if type(key) is int else tuple(self._row.keys()).index(key)]
         elif type(key) is Column:
             idx, datatype = self._column_map_full[str(key)]
         elif type(key) is int:

--- a/tests/test_databases.py
+++ b/tests/test_databases.py
@@ -202,6 +202,14 @@ async def test_queries_raw(database_url):
             assert result["text"] == "example2"
             assert result["completed"] == False
 
+            # fetch_val()
+            query = "SELECT completed FROM notes WHERE text = :text"
+            result = await database.fetch_val(query=query, values={"text": "example1"})
+            assert result == True
+            query = "SELECT completed FROM notes WHERE text = :text"
+            result = await database.fetch_val(query=query, values={"text": "example1"}, column="completed")
+            assert result == True
+
             # iterate()
             query = "SELECT * FROM notes"
             iterate_results = []


### PR DESCRIPTION
As of now, `fetch_val` does not work for raw queries in Postgres. Possibly related to the discussion in #101.

This is a simple fix that will distinguish between `row[0]` and `row['foo']` in the case of raw queries.

```python
await database.fetch_val("SELECT foo FROM bar")
```

in `core.py`:
```python
async def fetch_val(
    self,
    query: typing.Union[ClauseElement, str],
    values: dict = None,
    column: typing.Any = 0,
) -> typing.Any:
    async with self._query_lock:
        row = await self._connection.fetch_one(self._build_query(query, values))
    return None if row is None else row[column]
```

in `backends/postgres.py`:
```python
def __getitem__(self, key: typing.Any) -> typing.Any:
    if len(self._column_map) == 0:  # raw query
        return self._row[tuple(self._row.keys()).index(key)]
```

In this case, key is `0`, while `tuple(self.row.keys())` is `('id',)`, which raises `ValueError: tuple.index(x): x not in tuple`