### PR TITLE
Fix: execute() should return rows affected by operation if lastrowid is not set.

### DIFF
--- a/databases/backends/mysql.py
+++ b/databases/backends/mysql.py
@@ -131,7 +131,9 @@ class MySQLConnection(ConnectionBackend):
         cursor = await self._connection.cursor()
         try:
             await cursor.execute(query, args)
-            return cursor.rowcount
+            if cursor.lastrowid == 0:
+                return cursor.rowcount
+            return cursor.lastrowid
         finally:
             await cursor.close()
 

--- a/databases/backends/mysql.py
+++ b/databases/backends/mysql.py
@@ -131,7 +131,7 @@ class MySQLConnection(ConnectionBackend):
         cursor = await self._connection.cursor()
         try:
             await cursor.execute(query, args)
-            return cursor.lastrowid
+            return cursor.rowcount
         finally:
             await cursor.close()
 

--- a/databases/backends/sqlite.py
+++ b/databases/backends/sqlite.py
@@ -111,10 +111,14 @@ class SQLiteConnection(ConnectionBackend):
     async def execute(self, query: ClauseElement) -> typing.Any:
         assert self._connection is not None, "Connection is not acquired"
         query, args, context = self._compile(query)
-        cursor = await self._connection.execute(query, args)
-        rowcount = cursor.rowcount
-        await cursor.close()
-        return rowcount
+        cursor = await self._connection.cursor()
+        try:
+            await cursor.execute(query, args)
+            if cursor.lastrowid == 0:
+                return cursor.rowcount
+            return cursor.lastrowid
+        finally:
+            await cursor.close()
 
     async def execute_many(self, queries: typing.List[ClauseElement]) -> None:
         assert self._connection is not None, "Connection is not acquired"

--- a/databases/backends/sqlite.py
+++ b/databases/backends/sqlite.py
@@ -112,8 +112,9 @@ class SQLiteConnection(ConnectionBackend):
         assert self._connection is not None, "Connection is not acquired"
         query, args, context = self._compile(query)
         cursor = await self._connection.execute(query, args)
+        rowcount = cursor.rowcount
         await cursor.close()
-        return cursor.lastrowid
+        return rowcount
 
     async def execute_many(self, queries: typing.List[ClauseElement]) -> None:
         assert self._connection is not None, "Connection is not acquired"


### PR DESCRIPTION
Patch closes the following issues:
- https://github.com/encode/databases/issues/142
- https://github.com/encode/databases/issues/61

**Old behavior:** Calls to execute() return lastrowid. For some operations this has no benefit.

**New behavior:** Calls to execute() where lastrowid has no benefit will now return rows affected by the operation. (Example: DELETE. So we can now see if a DELETE was successful, and how many rows were deleted). Calls which set a lastrowid value, will still retain the old behavior.

The library encode/databases depends on, aiomysql, returns rows affected, the desired behaviour this patch implements. See: https://github.com/aio-libs/aiomysql/blob/master/aiomysql/cursors.py#L244