### PR TITLE
Add 'database.force_rollback()' context manager.

### DIFF
--- a/databases/core.py
+++ b/databases/core.py
@@ -188,7 +188,7 @@ class Database:
         return self.connection().transaction(force_rollback=force_rollback)
 
     @contextlib.contextmanager
-    def force_rollback(self):
+    def force_rollback(self) -> typing.Iterator[None]:
         initial = self._force_rollback
         self._force_rollback = True
         try:

--- a/databases/core.py
+++ b/databases/core.py
@@ -1,4 +1,5 @@
 import asyncio
+import contextlib
 import functools
 import logging
 import sys
@@ -185,6 +186,15 @@ class Database:
 
     def transaction(self, *, force_rollback: bool = False) -> "Transaction":
         return self.connection().transaction(force_rollback=force_rollback)
+
+    @contextlib.contextmanager
+    def force_rollback(self):
+        initial = self._force_rollback
+        self._force_rollback = True
+        try:
+            yield
+        finally:
+            self._force_rollback = initial
 
 
 class Connection:


### PR DESCRIPTION
Adds a context managed `database.force_rollback()`, rather than the global style `database = databases.Database(..., force_rollback=True)`.

Discovered that this makes sense when working towards a possible new version of `orm`.
Was trying to use `models.create_all()`/`models.drop_all()` in test cases, but it was failing because the database was setup with force-rollback transactions, which then *included* the case of "create the initial tables in the test database".

(We don't see that when using `sqlalchemy` directly, since we're using completely different sync drivers in that case.)

Leaving this undocumented at the moment, as still working towards something more comprehensive, based on this.