### PR TITLE
Failing test case for database.transaction() as a decorator

### DIFF
--- a/databases/__init__.py
+++ b/databases/__init__.py
@@ -1,4 +1,4 @@
 from databases.core import Database, DatabaseURL
 
-__version__ = "0.3.0"
+__version__ = "0.3.1"
 __all__ = ["Database", "DatabaseURL"]

--- a/databases/core.py
+++ b/databases/core.py
@@ -194,8 +194,6 @@ class Database:
             yield
         finally:
             self._force_rollback = False
-            self._global_transaction = None
-            self._global_connection = None
 
 
 class Connection:

--- a/databases/core.py
+++ b/databases/core.py
@@ -75,12 +75,6 @@ class Database:
         self._global_connection = None  # type: typing.Optional[Connection]
         self._global_transaction = None  # type: typing.Optional[Transaction]
 
-        if self._force_rollback:
-            self._global_connection = Connection(self._backend)
-            self._global_transaction = self._global_connection.transaction(
-                force_rollback=True
-            )
-
     async def connect(self) -> None:
         """
         Establish the connection pool.
@@ -94,7 +88,13 @@ class Database:
         self.is_connected = True
 
         if self._force_rollback:
-            assert self._global_transaction is not None
+            assert self._global_connection is None
+            assert self._global_transaction is None
+
+            self._global_connection = Connection(self._backend)
+            self._global_transaction = self._global_connection.transaction(
+                force_rollback=True
+            )
 
             await self._global_transaction.__aenter__()
 
@@ -105,9 +105,13 @@ class Database:
         assert self.is_connected, "Already disconnected."
 
         if self._force_rollback:
+            assert self._global_connection is not None
             assert self._global_transaction is not None
 
             await self._global_transaction.__aexit__()
+
+            self._global_transaction = None
+            self._global_connection = None
 
         await self._backend.disconnect()
         logger.info(
@@ -185,15 +189,12 @@ class Database:
 
     @contextlib.contextmanager
     def force_rollback(self) -> typing.Iterator[None]:
-        self._global_connection = Connection(self._backend)
-        self._global_transaction = self._global_connection.transaction(
-            force_rollback=True
-        )
+        initial = self._force_rollback
         self._force_rollback = True
         try:
             yield
         finally:
-            self._force_rollback = False
+            self._force_rollback = initial
 
 
 class Connection:

--- a/databases/core.py
+++ b/databases/core.py
@@ -185,7 +185,7 @@ class Database:
             return connection
 
     def transaction(self, *, force_rollback: bool = False) -> "Transaction":
-        return self.connection().transaction(force_rollback=force_rollback)
+        return Transaction(self.connection, force_rollback=force_rollback)
 
     @contextlib.contextmanager
     def force_rollback(self) -> typing.Iterator[None]:
@@ -275,7 +275,9 @@ class Connection:
                     yield record
 
     def transaction(self, *, force_rollback: bool = False) -> "Transaction":
-        return Transaction(self, force_rollback)
+        def connection_callable():
+            return self
+        return Transaction(connection_callable, force_rollback)
 
     @property
     def raw_connection(self) -> typing.Any:
@@ -296,10 +298,9 @@ class Connection:
 
 
 class Transaction:
-    def __init__(self, connection: Connection, force_rollback: bool) -> None:
-        self._connection = connection
+    def __init__(self, connection_callable: typing.Callable[[None], Connection], force_rollback: bool) -> None:
+        self._connection_callable = connection_callable
         self._force_rollback = force_rollback
-        self._transaction = connection._connection.transaction()
 
     async def __aenter__(self) -> "Transaction":
         """
@@ -341,6 +342,9 @@ class Transaction:
         return wrapper
 
     async def start(self) -> "Transaction":
+        self._connection = self._connection_callable()
+        self._transaction = self._connection._connection.transaction()
+
         async with self._connection._transaction_lock:
             is_root = not self._connection._transaction_stack
             await self._connection.__aenter__()

--- a/databases/core.py
+++ b/databases/core.py
@@ -194,6 +194,8 @@ class Database:
             yield
         finally:
             self._force_rollback = False
+            self._global_transaction = None
+            self._global_connection = None
 
 
 class Connection:

--- a/databases/core.py
+++ b/databases/core.py
@@ -275,8 +275,9 @@ class Connection:
                     yield record
 
     def transaction(self, *, force_rollback: bool = False) -> "Transaction":
-        def connection_callable():
+        def connection_callable() -> Connection:
             return self
+
         return Transaction(connection_callable, force_rollback)
 
     @property
@@ -298,7 +299,11 @@ class Connection:
 
 
 class Transaction:
-    def __init__(self, connection_callable: typing.Callable[[None], Connection], force_rollback: bool) -> None:
+    def __init__(
+        self,
+        connection_callable: typing.Callable[[], Connection],
+        force_rollback: bool,
+    ) -> None:
         self._connection_callable = connection_callable
         self._force_rollback = force_rollback
 

--- a/tests/test_databases.py
+++ b/tests/test_databases.py
@@ -451,15 +451,16 @@ async def test_transaction_decorator(database_url):
     """
     Ensure that @database.transaction() is supported.
     """
-    async with Database(database_url, force_rollback=True) as database:
+    database = Database(database_url, force_rollback=True)
 
-        @database.transaction()
-        async def insert_data(raise_exception):
-            query = notes.insert().values(text="example", completed=True)
-            await database.execute(query)
-            if raise_exception:
-                raise RuntimeError()
+    @database.transaction()
+    async def insert_data(raise_exception):
+        query = notes.insert().values(text="example", completed=True)
+        await database.execute(query)
+        if raise_exception:
+            raise RuntimeError()
 
+    async with database:
         with pytest.raises(RuntimeError):
             await insert_data(raise_exception=True)
 


### PR DESCRIPTION
Refs https://github.com/encode/databases/pull/158

Currently causing failures in Starlette test cases.

One resolution would be to rollback #158, until we've got an alternate tack that fixes #158 without regressing `@database.transaction()`. Alternately, we figure out a fix for both cases, and submit that.
