### PR TITLE
Access asyncpg Record field by key on raw query

### DIFF
--- a/databases/backends/postgres.py
+++ b/databases/backends/postgres.py
@@ -104,7 +104,7 @@ class Record(Mapping):
 
     def __getitem__(self, key: typing.Any) -> typing.Any:
         if len(self._column_map) == 0:  # raw query
-            return self._row[tuple(self._row.keys()).index(key)]
+            return self._row[key]
         elif isinstance(key, Column):
             idx, datatype = self._column_map_full[str(key)]
         elif isinstance(key, int):


### PR DESCRIPTION
I am using postgresql (asyncpg), and have a result set of about 5,000 records with 12 columns. 

When serializing the result set to another type I noticed that the step of reading the results from `databases.backends.postgres.Record` step was a bit of a bottleneck. 

After digging into the code I noticed that when there is no column map, the code was taking the `asyncpg.Record` object and turning its keys into a tuple and then doing an index lookup based on the key. I'm unclear on if this step is necessary, because you can access the fields on the `asyncpg.Record` by key directly via a dict lookup. 

After applying this change, the amount of time to serialize the result set I was working with was reduced rather dramatically (between 40-60%). I ran the unit tests and saw that they all past, but am happy to add others if there are cases you would like.