### PR TITLE
[doc typos] Updated transactions documentation for low-level usage.

### DIFF
--- a/docs/connections_and_transactions.md
+++ b/docs/connections_and_transactions.md
@@ -71,11 +71,12 @@ For a lower-level transaction API:
 ```python
 transaction = await database.transaction()
 try:
+    await transaction.start()
     ...
 except:
-    transaction.rollback()
+    await transaction.rollback()
 else:
-    transaction.commit()
+    await transaction.commit()
 ```
 
 You can also use `.transaction()` as a function decorator on any async function:


### PR DESCRIPTION
# Summary

*documentation update only* 

Using the lower-level API for Transactions requires that
`await transaction.start()` is called so `transaction._connection`
exists.

Also, low-level usage of transactions did not include the use of
`await` for `transaction.rollback()` and `.commit()`.