### PR TITLE
Avoid dangling task-local connections after Database.disconnect()

### DIFF
--- a/databases/core.py
+++ b/databases/core.py
@@ -119,7 +119,7 @@ class Database:
             self._global_transaction = None
             self._global_connection = None
         else:
-            self._connection_context = ContextVar("connection_context")
+            self._connection_context = contextvars.ContextVar("connection_context")
 
         await self._backend.disconnect()
         logger.info(

--- a/databases/core.py
+++ b/databases/core.py
@@ -112,6 +112,8 @@ class Database:
 
             self._global_transaction = None
             self._global_connection = None
+        else:
+            self._connection_context = ContextVar("connection_context")
 
         await self._backend.disconnect()
         logger.info(


### PR DESCRIPTION
This change forces initialization of a new Connection if we connect() again.