### PR TITLE
Fixed SQLAlchemy DDL statements

### DIFF
--- a/databases/backends/aiopg.py
+++ b/databases/backends/aiopg.py
@@ -189,9 +189,9 @@ class AiopgConnection(ConnectionBackend):
         execution_context = self._dialect.execution_ctx_cls()
         execution_context.dialect = self._dialect
         execution_context.result_column_struct = (
-            getattr(compiled, '_result_columns', ()),
-            getattr(compiled, '_ordered_columns', ()),
-            getattr(compiled, '_textual_ordered_columns', ()),
+            getattr(compiled, "_result_columns", ()),
+            getattr(compiled, "_ordered_columns", ()),
+            getattr(compiled, "_textual_ordered_columns", ()),
         )
 
         logger.debug("Query: %s\nArgs: %s", compiled.string, args)

--- a/databases/backends/aiopg.py
+++ b/databases/backends/aiopg.py
@@ -10,6 +10,7 @@ from sqlalchemy.dialects.postgresql.psycopg2 import PGDialect_psycopg2
 from sqlalchemy.engine.interfaces import Dialect, ExecutionContext
 from sqlalchemy.engine.result import ResultMetaData, RowProxy
 from sqlalchemy.sql import ClauseElement
+from sqlalchemy.sql.ddl import DDLElement
 from sqlalchemy.types import TypeEngine
 
 from databases.core import DatabaseURL
@@ -181,18 +182,23 @@ class AiopgConnection(ConnectionBackend):
         self, query: ClauseElement
     ) -> typing.Tuple[str, dict, CompilationContext]:
         compiled = query.compile(dialect=self._dialect)
-        args = compiled.construct_params()
-        for key, val in (args or {}).items():
-            if key in compiled._bind_processors:
-                args[key] = compiled._bind_processors[key](val)
 
         execution_context = self._dialect.execution_ctx_cls()
         execution_context.dialect = self._dialect
-        execution_context.result_column_struct = (
-            getattr(compiled, "_result_columns", ()),
-            getattr(compiled, "_ordered_columns", ()),
-            getattr(compiled, "_textual_ordered_columns", ()),
-        )
+
+        if not isinstance(query, DDLElement):
+            args = compiled.construct_params()
+            for key, val in args.items():
+                if key in compiled._bind_processors:
+                    args[key] = compiled._bind_processors[key](val)
+
+            execution_context.result_column_struct = (
+                compiled._result_columns,
+                compiled._ordered_columns,
+                compiled._textual_ordered_columns,
+            )
+        else:
+            args = {}
 
         logger.debug("Query: %s\nArgs: %s", compiled.string, args)
         return compiled.string, args, CompilationContext(execution_context)

--- a/databases/backends/aiopg.py
+++ b/databases/backends/aiopg.py
@@ -182,16 +182,16 @@ class AiopgConnection(ConnectionBackend):
     ) -> typing.Tuple[str, dict, CompilationContext]:
         compiled = query.compile(dialect=self._dialect)
         args = compiled.construct_params()
-        for key, val in args.items():
+        for key, val in (args or {}).items():
             if key in compiled._bind_processors:
                 args[key] = compiled._bind_processors[key](val)
 
         execution_context = self._dialect.execution_ctx_cls()
         execution_context.dialect = self._dialect
         execution_context.result_column_struct = (
-            compiled._result_columns,
-            compiled._ordered_columns,
-            compiled._textual_ordered_columns,
+            getattr(compiled, '_result_columns', ()),
+            getattr(compiled, '_ordered_columns', ()),
+            getattr(compiled, '_textual_ordered_columns', ()),
         )
 
         logger.debug("Query: %s\nArgs: %s", compiled.string, args)

--- a/databases/backends/mysql.py
+++ b/databases/backends/mysql.py
@@ -169,16 +169,16 @@ class MySQLConnection(ConnectionBackend):
     ) -> typing.Tuple[str, dict, CompilationContext]:
         compiled = query.compile(dialect=self._dialect)
         args = compiled.construct_params()
-        for key, val in args.items():
+        for key, val in (args or {}).items():
             if key in compiled._bind_processors:
                 args[key] = compiled._bind_processors[key](val)
 
         execution_context = self._dialect.execution_ctx_cls()
         execution_context.dialect = self._dialect
         execution_context.result_column_struct = (
-            compiled._result_columns,
-            compiled._ordered_columns,
-            compiled._textual_ordered_columns,
+            getattr(compiled, '_result_columns', ()),
+            getattr(compiled, '_ordered_columns', ()),
+            getattr(compiled, '_textual_ordered_columns', ()),
         )
 
         query_message = compiled.string.replace(" \n", " ").replace("\n", " ")

--- a/databases/backends/mysql.py
+++ b/databases/backends/mysql.py
@@ -176,9 +176,9 @@ class MySQLConnection(ConnectionBackend):
         execution_context = self._dialect.execution_ctx_cls()
         execution_context.dialect = self._dialect
         execution_context.result_column_struct = (
-            getattr(compiled, '_result_columns', ()),
-            getattr(compiled, '_ordered_columns', ()),
-            getattr(compiled, '_textual_ordered_columns', ()),
+            getattr(compiled, "_result_columns", ()),
+            getattr(compiled, "_ordered_columns", ()),
+            getattr(compiled, "_textual_ordered_columns", ()),
         )
 
         query_message = compiled.string.replace(" \n", " ").replace("\n", " ")

--- a/databases/backends/mysql.py
+++ b/databases/backends/mysql.py
@@ -8,6 +8,7 @@ from sqlalchemy.dialects.mysql import pymysql
 from sqlalchemy.engine.interfaces import Dialect, ExecutionContext
 from sqlalchemy.engine.result import ResultMetaData, RowProxy
 from sqlalchemy.sql import ClauseElement
+from sqlalchemy.sql.ddl import DDLElement
 from sqlalchemy.types import TypeEngine
 
 from databases.core import LOG_EXTRA, DatabaseURL
@@ -171,18 +172,23 @@ class MySQLConnection(ConnectionBackend):
         self, query: ClauseElement
     ) -> typing.Tuple[str, dict, CompilationContext]:
         compiled = query.compile(dialect=self._dialect)
-        args = compiled.construct_params()
-        for key, val in (args or {}).items():
-            if key in compiled._bind_processors:
-                args[key] = compiled._bind_processors[key](val)
 
         execution_context = self._dialect.execution_ctx_cls()
         execution_context.dialect = self._dialect
-        execution_context.result_column_struct = (
-            getattr(compiled, "_result_columns", ()),
-            getattr(compiled, "_ordered_columns", ()),
-            getattr(compiled, "_textual_ordered_columns", ()),
-        )
+
+        if not isinstance(query, DDLElement):
+            args = compiled.construct_params()
+            for key, val in args.items():
+                if key in compiled._bind_processors:
+                    args[key] = compiled._bind_processors[key](val)
+
+            execution_context.result_column_struct = (
+                compiled._result_columns,
+                compiled._ordered_columns,
+                compiled._textual_ordered_columns,
+            )
+        else:
+            args = {}
 
         query_message = compiled.string.replace(" \n", " ").replace("\n", " ")
         logger.debug("Query: %s Args: %s", query_message, repr(args), extra=LOG_EXTRA)

--- a/databases/backends/postgres.py
+++ b/databases/backends/postgres.py
@@ -202,14 +202,14 @@ class PostgresConnection(ConnectionBackend):
 
     def _compile(self, query: ClauseElement) -> typing.Tuple[str, list, tuple]:
         compiled = query.compile(dialect=self._dialect)
-        compiled_params = sorted(compiled.params.items())
+        compiled_params = sorted((compiled.params or {}).items())
 
         mapping = {
             key: "$" + str(i) for i, (key, _) in enumerate(compiled_params, start=1)
         }
         compiled_query = compiled.string % mapping
 
-        processors = compiled._bind_processors
+        processors = getattr(compiled, '_bind_processors', {})
         args = [
             processors[key](val) if key in processors else val
             for key, val in compiled_params
@@ -219,7 +219,7 @@ class PostgresConnection(ConnectionBackend):
         logger.debug(
             "Query: %s Args: %s", query_message, repr(tuple(args)), extra=LOG_EXTRA
         )
-        return compiled_query, args, compiled._result_columns
+        return compiled_query, args, getattr(compiled, '_result_columns', ())
 
     @staticmethod
     def _create_column_maps(

--- a/databases/backends/postgres.py
+++ b/databases/backends/postgres.py
@@ -209,7 +209,7 @@ class PostgresConnection(ConnectionBackend):
         }
         compiled_query = compiled.string % mapping
 
-        processors = getattr(compiled, '_bind_processors', {})
+        processors = getattr(compiled, "_bind_processors", {})
         args = [
             processors[key](val) if key in processors else val
             for key, val in compiled_params
@@ -219,7 +219,7 @@ class PostgresConnection(ConnectionBackend):
         logger.debug(
             "Query: %s Args: %s", query_message, repr(tuple(args)), extra=LOG_EXTRA
         )
-        return compiled_query, args, getattr(compiled, '_result_columns', ())
+        return compiled_query, args, getattr(compiled, "_result_columns", ())
 
     @staticmethod
     def _create_column_maps(

--- a/tests/test_databases.py
+++ b/tests/test_databases.py
@@ -238,6 +238,24 @@ async def test_queries_raw(database_url):
 
 @pytest.mark.parametrize("database_url", DATABASE_URLS)
 @async_adapter
+async def test_ddl_queries(database_url):
+    """
+    Test that the built-in DDL elements such as `DropTable()`,
+    `CreateTable()` are supported (using SQLAlchemy core).
+    """
+    async with Database(database_url) as database:
+        async with database.transaction(force_rollback=True):
+            # DropTable()
+            query = sqlalchemy.schema.DropTable(notes)
+            await database.execute(query)
+
+            # CreateTable()
+            query = sqlalchemy.schema.CreateTable(notes)
+            await database.execute(query)
+
+
+@pytest.mark.parametrize("database_url", DATABASE_URLS)
+@async_adapter
 async def test_results_support_mapping_interface(database_url):
     """
     Casting results to a dict should work, since the interface defines them


### PR DESCRIPTION
DDL statements made with SQLAlchemy (such as `sqlalchemy.schema.CreateTable`) used to have issues such as:

```
Traceback (most recent call last):
  File "../database.py", line 50, in <module>
    loop.run_until_complete(prepare_tables())
  File "/usr/lib/python3.8/asyncio/base_events.py", line 616, in run_until_complete
    return future.result()
  File "../database.py", line 40, in prepare_tables
    resp = await engine.fetch_one(query)
  File "/home/user/Documents/Projects/Python-Projects/test/databases/databases/core.py", line 146, in fetch_one
    return await connection.fetch_one(query, values)
  File "/home/user/Documents/Projects/Python-Projects/test/databases/databases/core.py", line 244, in fetch_one
    return await self._connection.fetch_one(built_query)
  File "/home/user/Documents/Projects/Python-Projects/test/databases/databases/backends/postgres.py", line 159, in fetch_one
    query, args, result_columns = self._compile(query)
  File "/home/user/Documents/Projects/Python-Projects/test/databases/databases/backends/postgres.py", line 205, in _compile
    compiled_params = sorted(compiled.params.items())
AttributeError: 'NoneType' object has no attribute 'items'
```

This PR fixes the issue for `postgres`, `aiopg`, and `mysql` backends.