### PR TITLE
Add support for MySQL unix_socket connection option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ __pycache__/
 *.egg-info/
 htmlcov/
 venv/
+.venv/

--- a/databases/backends/mysql.py
+++ b/databases/backends/mysql.py
@@ -35,6 +35,7 @@ class MySQLBackend(DatabaseBackend):
         max_size = url_options.get("max_size")
         pool_recycle = url_options.get("pool_recycle")
         ssl = url_options.get("ssl")
+        unix_socket = url_options.get("unix_socket")
 
         if min_size is not None:
             kwargs["minsize"] = int(min_size)
@@ -44,6 +45,8 @@ class MySQLBackend(DatabaseBackend):
             kwargs["pool_recycle"] = int(pool_recycle)
         if ssl is not None:
             kwargs["ssl"] = {"true": True, "false": False}[ssl.lower()]
+        if unix_socket is not None:
+            kwargs["unix_socket"] = unix_socket
 
         for key, value in self._options.items():
             # Coerce 'min_size' and 'max_size' for consistency.

--- a/databases/backends/mysql.py
+++ b/databases/backends/mysql.py
@@ -62,7 +62,7 @@ class MySQLBackend(DatabaseBackend):
         assert self._pool is None, "DatabaseBackend is already running"
         kwargs = self._get_connection_kwargs()
         if self._database_url.port:
-            kwargs['port'] = self._database_url.port
+            kwargs["port"] = self._database_url.port
 
         self._pool = await aiomysql.create_pool(
             host=self._database_url.hostname,

--- a/databases/backends/mysql.py
+++ b/databases/backends/mysql.py
@@ -61,9 +61,11 @@ class MySQLBackend(DatabaseBackend):
     async def connect(self) -> None:
         assert self._pool is None, "DatabaseBackend is already running"
         kwargs = self._get_connection_kwargs()
+        if self._database_url.port:
+            kwargs['port'] = self._database_url.port
+
         self._pool = await aiomysql.create_pool(
             host=self._database_url.hostname,
-            port=self._database_url.port or 3306,
             user=self._database_url.username or getpass.getuser(),
             password=self._database_url.password,
             db=self._database_url.database,

--- a/tests/test_connection_options.py
+++ b/tests/test_connection_options.py
@@ -73,6 +73,12 @@ def test_mysql_pool_recycle():
     assert kwargs == {"pool_recycle": 20}
 
 
+def test_mysql_unix_socket():
+    backend = MySQLBackend("mysql:///database?unix_socket=/tmp/mysqld/mysqld.sock")
+    kwargs = backend._get_connection_kwargs()
+    assert kwargs == {"unix_socket": "/tmp/mysqld/mysqld.sock"}
+
+
 def test_aiopg_pool_size():
     backend = AiopgBackend(
         "postgresql+aiopg://localhost/database?min_size=1&max_size=20"

--- a/tests/test_database_url.py
+++ b/tests/test_database_url.py
@@ -27,6 +27,9 @@ def test_database_url_options():
     u = DatabaseURL("postgresql://localhost/mydatabase?pool_size=20&ssl=true")
     assert u.options == {"pool_size": "20", "ssl": "true"}
 
+    u = DatabaseURL("mysql:///mydatabase?unix_socket=/tmp/mysqld/mysqld.sock")
+    assert u.options == {"unix_socket": "/tmp/mysqld/mysqld.sock"}
+
 
 def test_replace_database_url_components():
     u = DatabaseURL("postgresql://localhost/mydatabase")


### PR DESCRIPTION
Connection strings that specified `mysql:///db?unix_socket=...` option were not passing the `unix_socket` option to the underlying aiomysql connection. This meant that it was not possible to connect via UNIX domain socket unless the connection option was explicitly given to the `MySQLBackend()` constructor.

This change adds the `unix_socket` connection option to the explicit list of connection options recognized and extracted from the connection string.