### PR TITLE
Allowing extra transaction options

### DIFF
--- a/databases/backends/aiopg.py
+++ b/databases/backends/aiopg.py
@@ -215,7 +215,9 @@ class AiopgTransaction(TransactionBackend):
         self._is_root = False
         self._savepoint_name = ""
 
-    async def start(self, is_root: bool, extra_options: typing.Dict[typing.Any, typing.Any]) -> None:
+    async def start(
+        self, is_root: bool, extra_options: typing.Dict[typing.Any, typing.Any]
+    ) -> None:
         assert self._connection._connection is not None, "Connection is not acquired"
         self._is_root = is_root
         cursor = await self._connection._connection.cursor()

--- a/databases/backends/aiopg.py
+++ b/databases/backends/aiopg.py
@@ -215,7 +215,7 @@ class AiopgTransaction(TransactionBackend):
         self._is_root = False
         self._savepoint_name = ""
 
-    async def start(self, is_root: bool) -> None:
+    async def start(self, is_root: bool, extra_options: typing.Dict[typing.Any, typing.Any]) -> None:
         assert self._connection._connection is not None, "Connection is not acquired"
         self._is_root = is_root
         cursor = await self._connection._connection.cursor()

--- a/databases/backends/mysql.py
+++ b/databases/backends/mysql.py
@@ -206,7 +206,9 @@ class MySQLTransaction(TransactionBackend):
         self._is_root = False
         self._savepoint_name = ""
 
-    async def start(self, is_root: bool, extra_options: typing.Dict[typing.Any, typing.Any]) -> None:
+    async def start(
+        self, is_root: bool, extra_options: typing.Dict[typing.Any, typing.Any]
+    ) -> None:
         assert self._connection._connection is not None, "Connection is not acquired"
         self._is_root = is_root
         if self._is_root:

--- a/databases/backends/mysql.py
+++ b/databases/backends/mysql.py
@@ -206,7 +206,7 @@ class MySQLTransaction(TransactionBackend):
         self._is_root = False
         self._savepoint_name = ""
 
-    async def start(self, is_root: bool) -> None:
+    async def start(self, is_root: bool, extra_options: typing.Dict[typing.Any, typing.Any]) -> None:
         assert self._connection._connection is not None, "Connection is not acquired"
         self._is_root = is_root
         if self._is_root:

--- a/databases/backends/postgres.py
+++ b/databases/backends/postgres.py
@@ -278,9 +278,9 @@ class PostgresTransaction(TransactionBackend):
             None
         )  # type: typing.Optional[asyncpg.transaction.Transaction]
 
-    async def start(self, is_root: bool) -> None:
+    async def start(self, is_root: bool, extra_options: typing.Dict[typing.Any, typing.Any]) -> None:
         assert self._connection._connection is not None, "Connection is not acquired"
-        self._transaction = self._connection._connection.transaction()
+        self._transaction = self._connection._connection.transaction(**extra_options)
         await self._transaction.start()
 
     async def commit(self) -> None:

--- a/databases/backends/postgres.py
+++ b/databases/backends/postgres.py
@@ -278,7 +278,9 @@ class PostgresTransaction(TransactionBackend):
             None
         )  # type: typing.Optional[asyncpg.transaction.Transaction]
 
-    async def start(self, is_root: bool, extra_options: typing.Dict[typing.Any, typing.Any]) -> None:
+    async def start(
+        self, is_root: bool, extra_options: typing.Dict[typing.Any, typing.Any]
+    ) -> None:
         assert self._connection._connection is not None, "Connection is not acquired"
         self._transaction = self._connection._connection.transaction(**extra_options)
         await self._transaction.start()

--- a/databases/backends/sqlite.py
+++ b/databases/backends/sqlite.py
@@ -178,7 +178,9 @@ class SQLiteTransaction(TransactionBackend):
         self._is_root = False
         self._savepoint_name = ""
 
-    async def start(self, is_root: bool, extra_options: typing.Dict[typing.Any, typing.Any]) -> None:
+    async def start(
+        self, is_root: bool, extra_options: typing.Dict[typing.Any, typing.Any]
+    ) -> None:
         assert self._connection._connection is not None, "Connection is not acquired"
         self._is_root = is_root
         if self._is_root:

--- a/databases/backends/sqlite.py
+++ b/databases/backends/sqlite.py
@@ -178,7 +178,7 @@ class SQLiteTransaction(TransactionBackend):
         self._is_root = False
         self._savepoint_name = ""
 
-    async def start(self, is_root: bool) -> None:
+    async def start(self, is_root: bool, extra_options: typing.Dict[typing.Any, typing.Any]) -> None:
         assert self._connection._connection is not None, "Connection is not acquired"
         self._is_root = is_root
         if self._is_root:

--- a/databases/core.py
+++ b/databases/core.py
@@ -305,7 +305,7 @@ class Transaction:
         self,
         connection_callable: typing.Callable[[], Connection],
         force_rollback: bool,
-        **kwargs
+        **kwargs: typing.Any
     ) -> None:
         self._connection_callable = connection_callable
         self._force_rollback = force_rollback

--- a/databases/core.py
+++ b/databases/core.py
@@ -184,7 +184,9 @@ class Database:
             self._connection_context.set(connection)
             return connection
 
-    def transaction(self, *, force_rollback: bool = False, **kwargs: typing.Any) -> "Transaction":
+    def transaction(
+        self, *, force_rollback: bool = False, **kwargs: typing.Any
+    ) -> "Transaction":
         return Transaction(self.connection, force_rollback=force_rollback, **kwargs)
 
     @contextlib.contextmanager
@@ -276,7 +278,9 @@ class Connection:
                 async for record in self._connection.iterate(built_query):
                     yield record
 
-    def transaction(self, *, force_rollback: bool = False, **kwargs: typing.Any) -> "Transaction":
+    def transaction(
+        self, *, force_rollback: bool = False, **kwargs: typing.Any
+    ) -> "Transaction":
         def connection_callable() -> Connection:
             return self
 
@@ -305,7 +309,7 @@ class Transaction:
         self,
         connection_callable: typing.Callable[[], Connection],
         force_rollback: bool,
-        **kwargs: typing.Any
+        **kwargs: typing.Any,
     ) -> None:
         self._connection_callable = connection_callable
         self._force_rollback = force_rollback
@@ -357,7 +361,9 @@ class Transaction:
         async with self._connection._transaction_lock:
             is_root = not self._connection._transaction_stack
             await self._connection.__aenter__()
-            await self._transaction.start(is_root=is_root, extra_options=self._extra_options)
+            await self._transaction.start(
+                is_root=is_root, extra_options=self._extra_options
+            )
             self._connection._transaction_stack.append(self)
         return self
 

--- a/databases/interfaces.py
+++ b/databases/interfaces.py
@@ -56,7 +56,9 @@ class ConnectionBackend:
 
 
 class TransactionBackend:
-    async def start(self, is_root: bool, extra_options: typing.Dict[typing.Any, typing.Any]) -> None:
+    async def start(
+        self, is_root: bool, extra_options: typing.Dict[typing.Any, typing.Any]
+    ) -> None:
         raise NotImplementedError()  # pragma: no cover
 
     async def commit(self) -> None:

--- a/databases/interfaces.py
+++ b/databases/interfaces.py
@@ -56,7 +56,7 @@ class ConnectionBackend:
 
 
 class TransactionBackend:
-    async def start(self, is_root: bool) -> None:
+    async def start(self, is_root: bool, extra_options: typing.Dict[typing.Any, typing.Any]) -> None:
         raise NotImplementedError()  # pragma: no cover
 
     async def commit(self) -> None:

--- a/tests/test_databases.py
+++ b/tests/test_databases.py
@@ -453,7 +453,7 @@ async def test_transaction_commit_serializable(database_url):
             assert len(results) == 0
 
             event = asyncio.Event()
-            asyncio.create_task(insert_concurrently(event))
+            asyncio.ensure_future(insert_concurrently(event))
             await event.wait()
 
             query = notes.select()

--- a/tests/test_databases.py
+++ b/tests/test_databases.py
@@ -435,7 +435,7 @@ async def test_transaction_commit_serializable(database_url):
 
     database_url = DatabaseURL(database_url)
 
-    if database_url.dialect != "postgresql":
+    if database_url.scheme != "postgresql":
         pytest.skip("Test (currently) requires asyncpg")
 
     def insert_independently():

--- a/tests/test_databases.py
+++ b/tests/test_databases.py
@@ -436,7 +436,7 @@ async def test_transaction_commit_serializable(database_url):
     database_url = DatabaseURL(database_url)
 
     if database_url.scheme != "postgresql":
-        pytest.skip("Test (currently) requires asyncpg")
+        pytest.skip("Test (currently) only supports asyncpg")
 
     def insert_independently():
         engine = sqlalchemy.create_engine(str(database_url))


### PR DESCRIPTION
These changes make it possible to use advanced transaction options (currently only with asyncpg) such as different isolation levels or access modes.