### PR TITLE
Remove psycopg2 and pymysql from the direct dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 0.4.1 (October 21st, 2020)
+
+### Fixed
+
+* Remove package dependency on the synchronous DB drivers (#256)
+
 ## 0.4.0 (October 20th, 2020)
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ $ pip install databases[sqlite]
 ```
 
 Driver support is provided using one of [asyncpg][asyncpg], [aiomysql][aiomysql], or [aiosqlite][aiosqlite].
+Note that if you are using any synchronous SQLAlchemy functions such as `engine.create_all()` or [alembic][alembic] migrations then you still have to install a synchronous DB driver: [psycopg2][psycopg2] for PostgreSQL and [pymysql][pymysql] for MySQL.
 
 ---
 
@@ -93,6 +94,8 @@ for examples of how to start using databases together with SQLAlchemy core expre
 [sqlalchemy-core]: https://docs.sqlalchemy.org/en/latest/core/
 [sqlalchemy-core-tutorial]: https://docs.sqlalchemy.org/en/latest/core/tutorial.html
 [alembic]: https://alembic.sqlalchemy.org/en/latest/
+[psycopg2]: https://www.psycopg.org/
+[pymysql]: https://github.com/PyMySQL/PyMySQL
 [asyncpg]: https://github.com/MagicStack/asyncpg
 [aiomysql]: https://github.com/aio-libs/aiomysql
 [aiosqlite]: https://github.com/jreese/aiosqlite

--- a/databases/__init__.py
+++ b/databases/__init__.py
@@ -1,4 +1,4 @@
 from databases.core import Database, DatabaseURL
 
-__version__ = "0.4.0"
+__version__ = "0.4.1"
 __all__ = ["Database", "DatabaseURL"]

--- a/setup.py
+++ b/setup.py
@@ -50,8 +50,8 @@ setup(
     data_files=[("", ["LICENSE.md"])],
     install_requires=["sqlalchemy", 'aiocontextvars;python_version<"3.7"'],
     extras_require={
-        "postgresql": ["asyncpg", "psycopg2"],
-        "mysql": ["aiomysql", "pymysql"],
+        "postgresql": ["asyncpg"],
+        "mysql": ["aiomysql"],
         "sqlite": ["aiosqlite"],
         "postgresql+aiopg": ["aiopg"]
     },


### PR DESCRIPTION
Related to https://github.com/encode/databases/pull/204

This should fix my own builds and I guess other people's too.