### PR TITLE
postgres: pass DSN components as options or arguments

### DIFF
--- a/tests/test_database_url.py
+++ b/tests/test_database_url.py
@@ -54,6 +54,12 @@ def test_database_url_options():
     assert u.options == {"pool_size": "20", "ssl": "true"}
 
 
+def test_database_url_host_passed_as_option():
+    u = DatabaseURL("postgresql:///mydatabase?host=/var/run/postgresql/")
+    assert u.database == "mydatabase"
+    assert u.options == {"host": "/var/run/postgresql/"}
+
+
 def test_replace_database_url_components():
     u = DatabaseURL("postgresql://localhost/mydatabase")
 


### PR DESCRIPTION
Postgres libpq connection strings allow passing components of the URI as
parameters (for example `postgresql:///mydb?host=localhost&port=5433`,
as detailed here:
https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING).

This change allows the URI components to be passed as options, or as
keyword arguments (which will override connection string components)

The functionality is essential in the context of connecting via unix
socket since python's url parser will not parse an absolute path as a
hostname.

fix #257

Signed-off-by: Uri Okrent <uokrent@gmail.com>