### PR TITLE
Fix memory leak with asyncpg, for SQLAlchemy generic functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## Unreleased
+
+### Fixed
+
+* Fix memory leak with asyncpg, for SQLAlchemy generic functions (#273)
+
 ## 0.4.1 (November 16th, 2020)
 
 ### Fixed

--- a/databases/backends/postgres.py
+++ b/databases/backends/postgres.py
@@ -16,9 +16,6 @@ from databases.interfaces import ConnectionBackend, DatabaseBackend, Transaction
 logger = logging.getLogger("databases")
 
 
-_result_processors = {}  # type: dict
-
-
 class PostgresBackend(DatabaseBackend):
     def __init__(
         self, database_url: typing.Union[DatabaseURL, str], **options: typing.Any
@@ -120,11 +117,7 @@ class Record(Mapping):
         else:
             idx, datatype = self._column_map[key]
         raw = self._row[idx]
-        try:
-            processor = _result_processors[datatype]
-        except KeyError:
-            processor = datatype.result_processor(self._dialect, None)
-            _result_processors[datatype] = processor
+        processor = datatype._cached_result_processor(self._dialect, None)
 
         if processor is not None:
             return processor(raw)


### PR DESCRIPTION
Use SQLAlchemy caching logic for data type's result processors, instead of handling it in this library.

Fixes #272