### PR TITLE
Fixed counter on failed connection

### DIFF
--- a/databases/core.py
+++ b/databases/core.py
@@ -215,8 +215,12 @@ class Connection:
     async def __aenter__(self) -> "Connection":
         async with self._connection_lock:
             self._connection_counter += 1
-            if self._connection_counter == 1:
-                await self._connection.acquire()
+            try:
+                if self._connection_counter == 1:
+                    await self._connection.acquire()
+            except Exception as e:
+                self._connection_counter -= 1
+                raise e
         return self
 
     async def __aexit__(


### PR DESCRIPTION
Sometimes `self._connection.acquire()` can throw an exception and `self._connection_counter` will remain 1, in that case, if we try to reconnect `__aenter__` will always skip `self._connection.acquire()` and we won't be able to make any further requests to database.