### PR TITLE
Fix DatabaseURL string representation

### DIFF
--- a/databases/core.py
+++ b/databases/core.py
@@ -392,7 +392,7 @@ class DatabaseURL:
         if isinstance(url, DatabaseURL):
             self._url: str = url._url
         elif isinstance(url, str):
-            self._url = url
+            self._url = str(url)
         else:
             raise TypeError(
                 f"Invalid type for DatabaseURL. Expected str or DatabaseURL, got {type(url)}"

--- a/tests/test_database_url.py
+++ b/tests/test_database_url.py
@@ -17,6 +17,22 @@ def test_database_url_repr():
     assert repr(u) == "DatabaseURL('postgresql://username:********@localhost/name')"
 
 
+def test_database_url_str():
+    Str = type("Str", (str,), {"__repr__": lambda self: ""})
+
+    u = DatabaseURL(Str("postgresql://localhost/name"))
+    assert str(u) == "postgresql://localhost/name"
+
+    u = DatabaseURL(Str("postgresql://username@localhost/name"))
+    assert str(u) == "postgresql://username@localhost/name"
+
+    u = DatabaseURL(Str("postgresql://username:password@localhost/name"))
+    assert str(u) == "postgresql://username:password@localhost/name"
+
+    u = DatabaseURL(Str(f"postgresql://username:{quote('[password')}@localhost/name"))
+    assert str(u) == "postgresql://username:%5Bpassword@localhost/name"
+
+
 def test_database_url_properties():
     u = DatabaseURL("postgresql+asyncpg://username:password@localhost:123/mydatabase")
     assert u.dialect == "postgresql"


### PR DESCRIPTION
This fixes string representation of `DatabaseURL` objects.

Here is a script to reproduce problem:

```python
from databases import Database, DatabaseURL
from pydantic import BaseSettings, PostgresDsn


class Settings(BaseSettings):
    dsn: PostgresDsn
 

dsn = DatabaseURL(Settings(dsn='postgres://user:pass@localhost/name').dsn)
db = Database(dsn)
str(db.url)
# TypeError: __init__() needs keyword-only argument scheme
```

The problem appears when `DatabaseURL`'s argument `url` is an instance of a class that derived from `str` and has overriden `__repr__()` method:

```python
from databases import DatabaseURL

Str = type('Str', (str, ), {'__repr__': lambda self: 'Lorem ipsum dolor sit amet...'})

dsn = DatabaseURL(Str('postgres://user:pass@localhost/name'))
dsn
# DatabaseURL('postgres://user:********@localhost/name')
print(dsn)
# postgres://user:pass@localhost/name
str(dsn)
# Lorem ipsum dolor sit amet...
```

After this fix:

```python
from databases import DatabaseURL

Str = type('Str', (str, ), {'__repr__': lambda self: 'Lorem ipsum dolor sit amet...'})

dsn = DatabaseURL(Str('postgres://user:pass@localhost/name'))
dsn
# DatabaseURL('postgres://user:********@localhost/name')
print(dsn)
# postgres://user:pass@localhost/name
str(dsn)
# 'postgres://user:pass@localhost/name'
```