### PR TITLE
Fix aiopg tests hanging

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -47,5 +47,5 @@ jobs:
         run: "scripts/install"
       - name: "Run tests"
         env:
-          TEST_DATABASE_URLS: "sqlite:///testsuite, mysql://username:password@localhost:3306/testsuite, postgresql://username:password@localhost:5432/testsuite, postgresql+aiopg://username:password@localhost:5432/testsuite"
+          TEST_DATABASE_URLS: "sqlite:///testsuite, mysql://username:password@localhost:3306/testsuite, postgresql://username:password@localhost:5432/testsuite, postgresql+aiopg://username:password@127.0.0.1:5432/testsuite"
         run: "scripts/test"


### PR DESCRIPTION
Apparently there's a bug for [aiopg](https://github.com/aio-libs/aiopg/issues/275) where it can hang while trying to connect to the DB if `localhost` is used in the connection URL instead of 127.0.0.1