### PR TITLE
Version 0.4.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 0.4.3 (March 26th, 2021)
+
+### Fixed
+
+* Pin SQLAlchemy to 1.13.*
+
 ## 0.4.2 (March 14th, 2021)
 
 ### Fixed
@@ -34,4 +40,3 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 * Fix SQLAlchemy DDL statements (#226)
 * Make fetch_val call fetch_one for type conversion (#246)
 * Unquote username and password in DatabaseURL (#248)
-

--- a/databases/__init__.py
+++ b/databases/__init__.py
@@ -1,4 +1,4 @@
 from databases.core import Database, DatabaseURL
 
-__version__ = "0.4.2"
+__version__ = "0.4.3"
 __all__ = ["Database", "DatabaseURL"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,7 @@
 # Notes...
 # The JSONField tests require sqlalchemy 1.3+. Other cases work at lower versions.
 # The aiocontextvars package is only required as a backport for Python 3.6.
-sqlalchemy>=1.3.0
-aiocontextvars;python_version<"3.7"
+-e .
 
 # Async database drivers
 aiomysql

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
     packages=get_packages("databases"),
     package_data={"databases": ["py.typed"]},
     data_files=[("", ["LICENSE.md"])],
-    install_requires=["sqlalchemy", 'aiocontextvars;python_version<"3.7"'],
+    install_requires=["sqlalchemy==1.13.*", 'aiocontextvars;python_version<"3.7"'],
     extras_require={
         "postgresql": ["asyncpg"],
         "mysql": ["aiomysql"],

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
     packages=get_packages("databases"),
     package_data={"databases": ["py.typed"]},
     data_files=[("", ["LICENSE.md"])],
-    install_requires=['sqlalchemy<1.14', 'aiocontextvars;python_version<"3.7"'],
+    install_requires=['sqlalchemy<1.4', 'aiocontextvars;python_version<"3.7"'],
     extras_require={
         "postgresql": ["asyncpg"],
         "mysql": ["aiomysql"],

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
     packages=get_packages("databases"),
     package_data={"databases": ["py.typed"]},
     data_files=[("", ["LICENSE.md"])],
-    install_requires=["sqlalchemy==1.13.*", 'aiocontextvars;python_version<"3.7"'],
+    install_requires=['sqlalchemy<1.14', 'aiocontextvars;python_version<"3.7"'],
     extras_require={
         "postgresql": ["asyncpg"],
         "mysql": ["aiomysql"],


### PR DESCRIPTION
Draft release: https://github.com/encode/databases/releases/tag/untagged-8c2d4a16059d155a08e9

---

## 0.4.3 (March 26th, 2021)

### Fixed

* Pin SQLAlchemy to 1.13.*