### PR TITLE
fix concurrency issues of parallel transactions (#327)

### DIFF
--- a/databases/core.py
+++ b/databases/core.py
@@ -68,7 +68,9 @@ class Database:
         self._backend = backend_cls(self.url, **self.options)
 
         # Connections are stored as task-local state.
-        self._connection_context = contextvars.ContextVar("connection_context")  # type: contextvars.ContextVar
+        self._connection_context = contextvars.ContextVar(
+            "connection_context"
+        )  # type: contextvars.ContextVar
 
         # When `force_rollback=True` is used, we use a single global
         # connection, within a transaction that always rolls back.

--- a/databases/core.py
+++ b/databases/core.py
@@ -373,7 +373,6 @@ class Transaction:
     async def start(self) -> "Transaction":
         self._connection = self._connection_callable()
         self._transaction = self._connection._connection.transaction()
-        logger.warning(self._connection)
 
         async with self._connection._transaction_lock:
             is_root = not self._connection._transaction_stack

--- a/databases/core.py
+++ b/databases/core.py
@@ -15,10 +15,8 @@ from databases.interfaces import ConnectionBackend, DatabaseBackend, Transaction
 
 if sys.version_info >= (3, 7):  # pragma: no cover
     import contextvars as contextvars
-    from contextvars import ContextVar
 else:  # pragma: no cover
     import aiocontextvars as contextvars
-    from aiocontextvars import ContextVar
 
 try:  # pragma: no cover
     import click
@@ -70,7 +68,7 @@ class Database:
         self._backend = backend_cls(self.url, **self.options)
 
         # Connections are stored as task-local state.
-        self._connection_context = ContextVar("connection_context")  # type: ContextVar
+        self._connection_context = contextvars.ContextVar("connection_context")  # type: contextvars.ContextVar
 
         # When `force_rollback=True` is used, we use a single global
         # connection, within a transaction that always rolls back.

--- a/databases/core.py
+++ b/databases/core.py
@@ -192,7 +192,7 @@ class Database:
     def transaction(
         self, *, force_rollback: bool = False, **kwargs: typing.Any
     ) -> "Transaction":
-        try: 
+        try:
             connection = self._connection_context.get()
             is_root = not connection._transaction_stack
             if is_root:

--- a/databases/core.py
+++ b/databases/core.py
@@ -194,9 +194,10 @@ class Database:
     ) -> "Transaction":
         try: 
             connection = self._connection_context.get()
-            if not connection._transaction_stack:
+            is_root = not connection._transaction_stack
+            if is_root:
                 newcontext = contextvars.copy_context()
-                get_conn  = lambda: newcontext.run(self._new_connection)
+                get_conn = lambda: newcontext.run(self._new_connection)
             else:
                 get_conn = self.connection
         except LookupError:

--- a/databases/core.py
+++ b/databases/core.py
@@ -5,7 +5,7 @@ import logging
 import sys
 import typing
 from types import TracebackType
-from urllib.parse import SplitResult, parse_qsl, urlsplit, unquote
+from urllib.parse import SplitResult, parse_qsl, unquote, urlsplit
 
 from sqlalchemy import text
 from sqlalchemy.sql import ClauseElement
@@ -14,11 +14,11 @@ from databases.importer import import_from_string
 from databases.interfaces import ConnectionBackend, DatabaseBackend, TransactionBackend
 
 if sys.version_info >= (3, 7):  # pragma: no cover
-    from contextvars import ContextVar
     import contextvars as contextvars
+    from contextvars import ContextVar
 else:  # pragma: no cover
-    from aiocontextvars import ContextVar
     import aiocontextvars as contextvars
+    from aiocontextvars import ContextVar
 
 try:  # pragma: no cover
     import click

--- a/docs/connections_and_transactions.md
+++ b/docs/connections_and_transactions.md
@@ -64,7 +64,7 @@ Transactions are managed by async context blocks:
 ```python
 async with database.connection() as connection:
     async with connection.transaction():
-    ...
+        ...
 ```
 
 For a lower-level transaction API:

--- a/docs/connections_and_transactions.md
+++ b/docs/connections_and_transactions.md
@@ -78,7 +78,7 @@ async with database.connection() as connection:
 For a lower-level transaction API:
 
 ```python
-transaction = await connection.transaction()
+transaction = await database.transaction()
 try:
     await transaction.start()
     ...

--- a/docs/connections_and_transactions.md
+++ b/docs/connections_and_transactions.md
@@ -59,7 +59,15 @@ database = Database('postgresql://localhost/example', ssl=True, min_size=5, max_
 
 ## Transactions
 
-Transactions are managed by async context blocks:
+Transactions are managed by async context blocks.
+
+A transaction can be acquired from the database connection pool:
+
+```python
+async with database.transaction():
+    ...
+```
+It can also be acquired from a specific database connection:
 
 ```python
 async with database.connection() as connection:

--- a/docs/connections_and_transactions.md
+++ b/docs/connections_and_transactions.md
@@ -62,14 +62,15 @@ database = Database('postgresql://localhost/example', ssl=True, min_size=5, max_
 Transactions are managed by async context blocks:
 
 ```python
-async with database.transaction():
+async with database.connection() as connection:
+    async with connection.transaction():
     ...
 ```
 
 For a lower-level transaction API:
 
 ```python
-transaction = await database.transaction()
+transaction = await connection.transaction()
 try:
     await transaction.start()
     ...

--- a/tests/test_database_url.py
+++ b/tests/test_database_url.py
@@ -1,6 +1,8 @@
-from databases import DatabaseURL
 from urllib.parse import quote
+
 import pytest
+
+from databases import DatabaseURL
 
 
 def test_database_url_repr():

--- a/tests/test_databases.py
+++ b/tests/test_databases.py
@@ -800,7 +800,7 @@ async def test_queries_with_expose_backend_connection(database_url):
     """
     async with Database(database_url) as database:
         async with database.connection() as connection:
-            async with database.transaction(force_rollback=True):
+            async with connection.transaction(force_rollback=True):
                 # Get the raw connection
                 raw_connection = connection.raw_connection
 
@@ -996,3 +996,20 @@ async def test_column_names(database_url, select_query):
             assert sorted(results[0].keys()) == ["completed", "id", "text"]
             assert results[0]["text"] == "example1"
             assert results[0]["completed"] == True
+
+@pytest.mark.parametrize("database_url", DATABASE_URLS)
+@async_adapter
+async def test_parallel_transactions(database_url):
+    """
+    Test parallel transaction execution. 
+    """
+    async def test_task(db): 
+        async with db.transaction():
+            await db.fetch_one("SELECT 1")
+
+    async with Database(database_url) as database:
+        await database.fetch_one("SELECT 1")
+
+        tasks = [test_task(database) for i in range(4)]
+        await asyncio.gather(*tasks)
+

--- a/tests/test_databases.py
+++ b/tests/test_databases.py
@@ -997,13 +997,15 @@ async def test_column_names(database_url, select_query):
             assert results[0]["text"] == "example1"
             assert results[0]["completed"] == True
 
+
 @pytest.mark.parametrize("database_url", DATABASE_URLS)
 @async_adapter
 async def test_parallel_transactions(database_url):
     """
-    Test parallel transaction execution. 
+    Test parallel transaction execution.
     """
-    async def test_task(db): 
+
+    async def test_task(db):
         async with db.transaction():
             await db.fetch_one("SELECT 1")
 
@@ -1012,4 +1014,3 @@ async def test_parallel_transactions(database_url):
 
         tasks = [test_task(database) for i in range(4)]
         await asyncio.gather(*tasks)
-


### PR DESCRIPTION
This is the proposed solution for async transaction execution failure (see #327 )  

Tests are running fine for postgres, mysql, sqlite. 

I had to change the test tests/test_databases.py because it incorrectly expects  database.transaction() to use the same connection as the connection context around it, which is certainly not true (and actually the part of the problem). If I acquire a connection, I have to use that connection for a transaction. (Requesting the database directly may give any other connection from the pool). 

All comments are welcome.

