### PR TITLE
Use `executemany` from backends

### DIFF
--- a/databases/backends/mysql.py
+++ b/databases/backends/mysql.py
@@ -144,10 +144,9 @@ class MySQLConnection(ConnectionBackend):
     async def execute_many(self, queries: typing.List[ClauseElement]) -> None:
         assert self._connection is not None, "Connection is not acquired"
         cursor = await self._connection.cursor()
+        query, values = self._compile_many(queries)
         try:
-            for single_query in queries:
-                single_query, args, context = self._compile(single_query)
-                await cursor.execute(single_query, args)
+            await cursor.executemany(query, values)
         finally:
             await cursor.close()
 
@@ -193,6 +192,16 @@ class MySQLConnection(ConnectionBackend):
         query_message = compiled.string.replace(" \n", " ").replace("\n", " ")
         logger.debug("Query: %s Args: %s", query_message, repr(args), extra=LOG_EXTRA)
         return compiled.string, args, CompilationContext(execution_context)
+
+    def _compile_many(
+        self, queries: typing.List[ClauseElement]
+    ) -> typing.Tuple[str, typing.Sequence[dict]]:
+        """
+        Compile single query and list of values for executemany method.
+        """
+        compiled_queries = [self._compile(query) for query in queries]
+        compiled_values = [compiled_query[1] for compiled_query in compiled_queries]
+        return compiled_queries[0][0], compiled_values
 
     @property
     def raw_connection(self) -> aiomysql.connection.Connection:

--- a/databases/backends/mysql.py
+++ b/databases/backends/mysql.py
@@ -214,7 +214,7 @@ class MySQLConnection(ConnectionBackend):
 
     def _compile_many(
         self, queries: typing.List[ClauseElement]
-    ) -> typing.Tuple[str, typing.Sequence[dict]]:
+    ) -> typing.Tuple[str, typing.List[dict]]:
         """
         Compile single query and list of values for executemany method.
         """

--- a/databases/backends/postgres.py
+++ b/databases/backends/postgres.py
@@ -190,12 +190,14 @@ class PostgresConnection(ConnectionBackend):
 
     async def execute_many(self, queries: typing.List[ClauseElement]) -> None:
         assert self._connection is not None, "Connection is not acquired"
-        # asyncpg uses prepared statements under the hood, so we just
-        # loop through multiple executes here, which should all end up
-        # using the same prepared statement.
+        query = ""
+        values = []
+
         for single_query in queries:
-            single_query, args, result_columns = self._compile(single_query)
-            await self._connection.execute(single_query, *args)
+            query, args, _ = self._compile(single_query)
+            values.append(args)
+
+        await self._connection.executemany(query, values)
 
     async def iterate(
         self, query: ClauseElement


### PR DESCRIPTION
Closes #284 

Some of the backends support `executemany` and instead of running multiple single queries we can use `executemany`.
asyncpg, aiosqlite and aiomysql support `executemany` but `aiopg` doesn't support it.