### PR TITLE
Failed connection counter reset

### DIFF
--- a/databases/core.py
+++ b/databases/core.py
@@ -237,8 +237,12 @@ class Connection:
     async def __aenter__(self) -> "Connection":
         async with self._connection_lock:
             self._connection_counter += 1
-            if self._connection_counter == 1:
-                await self._connection.acquire()
+            try:
+                if self._connection_counter == 1:
+                    await self._connection.acquire()
+            except Exception as e:
+                self._connection_counter -= 1
+                raise e
         return self
 
     async def __aexit__(

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,6 @@ psycopg2-binary
 pymysql
 
 # Testing
-asyncmock
 autoflake
 black
 codecov

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,6 +14,7 @@ psycopg2-binary
 pymysql
 
 # Testing
+asyncmock
 autoflake
 black
 codecov

--- a/tests/test_databases.py
+++ b/tests/test_databases.py
@@ -283,16 +283,12 @@ async def test_queries_after_error(database_url):
         ):
             with pytest.raises(Exception, match="boo!"):
                 async with database.transaction(force_rollback=True):
-                    query = notes.insert()
-                    values = {"text": "example1", "completed": True}
-                    await database.execute(query, values)
+                    query = notes.select()
+                    await database.fetch_all(query)
 
         async with database.transaction(force_rollback=True):
-            # execute()
-            query = notes.insert()
-            values = {"text": "example1", "completed": True}
-
-            await database.execute(query, values)
+            query = notes.select()
+            await database.fetch_all(query)
 
 
 @pytest.mark.parametrize("database_url", DATABASE_URLS)

--- a/tests/test_databases.py
+++ b/tests/test_databases.py
@@ -282,13 +282,11 @@ async def test_queries_after_error(database_url):
             new=AsyncMock(side_effect=Exception("boo!")),
         ):
             with pytest.raises(Exception, match="boo!"):
-                async with database.transaction(force_rollback=True):
-                    query = notes.select()
-                    await database.fetch_all(query)
+                query = notes.select()
+                await database.fetch_all(query)
 
-        async with database.transaction(force_rollback=True):
-            query = notes.select()
-            await database.fetch_all(query)
+        query = notes.select()
+        await database.fetch_all(query)
 
 
 @pytest.mark.parametrize("database_url", DATABASE_URLS)


### PR DESCRIPTION
This adds a unittest for #283.  It does require the library `asyncmock` as AsyncMock isn't available in python 3.6 or 3.7 yet.  If testing on 3.6 and 3.6 is not a requirement, we can use unittest.mocks.AsyncMock since it's included in python 3.8.

@aminalaee 