### PR TITLE
Removed LICENSE.md from data_files in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,6 @@ setup(
     author_email="tom@tomchristie.com",
     packages=get_packages("databases"),
     package_data={"databases": ["py.typed"]},
-    data_files=[("", ["LICENSE.md"])],
     install_requires=['sqlalchemy>=1.4,<1.5', 'aiocontextvars;python_version<"3.7"'],
     extras_require={
         "postgresql": ["asyncpg"],


### PR DESCRIPTION
Having this declaration will cause the LICENSE.md file to be copied into the current directly when you install databases in a virtual environment. This can overwrite the project's own license file, causing you to accidentally commit the encode license into your own project.