### PR TITLE
allow iterating over custom number of records with asyncpg

### DIFF
--- a/databases/backends/aiopg.py
+++ b/databases/backends/aiopg.py
@@ -190,7 +190,9 @@ class AiopgConnection(ConnectionBackend):
                 metadata._keymap,
                 Row._default_key_style
             )
-            while rows := await cursor.fetchmany(n):
+            while True:
+                rows = await cursor.fetchmany(n)
+                if not rows: break
                 records = list(map(row_func, rows))
                 yield records[0] if n == 1 else records
         finally:

--- a/databases/backends/aiopg.py
+++ b/databases/backends/aiopg.py
@@ -192,7 +192,7 @@ class AiopgConnection(ConnectionBackend):
             )
             while True:
                 rows = await cursor.fetchmany(n)
-                if not rows: break
+                if not len(rows): break
                 records = list(map(row_func, rows))
                 yield records[0] if n == 1 else records
         finally:

--- a/databases/backends/mysql.py
+++ b/databases/backends/mysql.py
@@ -182,7 +182,7 @@ class MySQLConnection(ConnectionBackend):
             )
             while True:
                 rows = await cursor.fetchmany(n)
-                if not rows: break
+                if not len(rows): break
                 records = list(map(row_func, rows))
                 yield records[0] if n == 1 else records
         finally:

--- a/databases/backends/mysql.py
+++ b/databases/backends/mysql.py
@@ -180,7 +180,9 @@ class MySQLConnection(ConnectionBackend):
                 metadata._keymap,
                 Row._default_key_style,
             )
-            while rows := await cursor.fetchmany(n):
+            while True:
+                rows = await cursor.fetchmany(n)
+                if not rows: break
                 records = list(map(row_func, rows))
                 yield records[0] if n == 1 else records
         finally:

--- a/databases/backends/postgres.py
+++ b/databases/backends/postgres.py
@@ -231,7 +231,7 @@ class PostgresConnection(ConnectionBackend):
             dialect=self._dialect,
             column_maps=column_maps
         )
-        cursor = await self._create_column_maps(result_columns)
+        cursor = await self._connection.cursor(query_str, *args)
         while rows := await cursor.fetch(n):
             results = list(map(record_func, rows))
             return results[0] if n == 1 else results

--- a/databases/backends/postgres.py
+++ b/databases/backends/postgres.py
@@ -232,7 +232,9 @@ class PostgresConnection(ConnectionBackend):
             column_maps=column_maps
         )
         cursor = await self._connection.cursor(query_str, *args)
-        while rows := await cursor.fetch(n):
+        while True:
+            rows = await cursor.fetch(n)
+            if not rows: break
             records = list(map(record_func, rows))
             yield records[0] if n == 1 else records
 

--- a/databases/backends/postgres.py
+++ b/databases/backends/postgres.py
@@ -234,7 +234,7 @@ class PostgresConnection(ConnectionBackend):
         cursor = await self._connection.cursor(query_str, *args)
         while rows := await cursor.fetch(n):
             results = list(map(record_func, rows))
-            return results[0] if n == 1 else results
+            yield results[0] if n == 1 else results
 
     def transaction(self) -> TransactionBackend:
         return PostgresTransaction(connection=self)

--- a/databases/backends/postgres.py
+++ b/databases/backends/postgres.py
@@ -233,8 +233,8 @@ class PostgresConnection(ConnectionBackend):
         )
         cursor = await self._connection.cursor(query_str, *args)
         while rows := await cursor.fetch(n):
-            results = list(map(record_func, rows))
-            yield results[0] if n == 1 else results
+            records = list(map(record_func, rows))
+            yield records[0] if n == 1 else records
 
     def transaction(self) -> TransactionBackend:
         return PostgresTransaction(connection=self)

--- a/databases/backends/sqlite.py
+++ b/databases/backends/sqlite.py
@@ -152,7 +152,7 @@ class SQLiteConnection(ConnectionBackend):
             )
             while True:
                 rows = await cursor.fetchmany(n)
-                if not rows: break
+                if not len(rows): break
                 records = list(map(row_func, rows))
                 yield records[0] if n == 1 else records
 

--- a/databases/backends/sqlite.py
+++ b/databases/backends/sqlite.py
@@ -150,7 +150,9 @@ class SQLiteConnection(ConnectionBackend):
                 metadata._keymap,
                 Row._default_key_style
             )
-            while rows := await cursor.fetchmany(n):
+            while True:
+                rows = await cursor.fetchmany(n)
+                if not rows: break
                 records = list(map(row_func, rows))
                 yield records[0] if n == 1 else records
 

--- a/databases/core.py
+++ b/databases/core.py
@@ -175,10 +175,10 @@ class Database:
             return await connection.execute_many(query, values)
 
     async def iterate(
-        self, query: typing.Union[ClauseElement, str], values: dict = None
+        self, query: typing.Union[ClauseElement, str], values: dict = None, *, n: int = None
     ) -> typing.AsyncGenerator[typing.Mapping, None]:
         async with self.connection() as connection:
-            async for record in connection.iterate(query, values):
+            async for record in connection.iterate(query, values, n=n):
                 yield record
 
     def _new_connection(self) -> "Connection":

--- a/databases/core.py
+++ b/databases/core.py
@@ -175,10 +175,10 @@ class Database:
             return await connection.execute_many(query, values)
 
     async def iterate(
-        self, query: typing.Union[ClauseElement, str], values: dict = None, *, n: int = None
+        self, query: typing.Union[ClauseElement, str], values: dict = None, **kwargs
     ) -> typing.AsyncGenerator[typing.Mapping, None]:
         async with self.connection() as connection:
-            async for record in connection.iterate(query, values, n=n):
+            async for record in connection.iterate(query, values, **kwargs):
                 yield record
 
     def _new_connection(self) -> "Connection":
@@ -301,12 +301,12 @@ class Connection:
             await self._connection.execute_many(queries)
 
     async def iterate(
-        self, query: typing.Union[ClauseElement, str], values: dict = None
+        self, query: typing.Union[ClauseElement, str], values: dict = None, **kwargs
     ) -> typing.AsyncGenerator[typing.Any, None]:
         built_query = self._build_query(query, values)
         async with self.transaction():
             async with self._query_lock:
-                async for record in self._connection.iterate(built_query):
+                async for record in self._connection.iterate(built_query, **kwargs):
                     yield record
 
     def transaction(

--- a/docs/database_queries.md
+++ b/docs/database_queries.md
@@ -65,9 +65,15 @@ row = await database.fetch_one(query=query)
 query = notes.select()
 value = await database.fetch_val(query=query)
 
-# Fetch multiple rows without loading them all into memory at once
+# Fetch multiple rows without loading them all into memory at once (1 at a time)
 query = notes.select()
 async for row in database.iterate(query=query):
+    ...
+
+# Fetch multiple rows loading n of them into memory at a time
+query = notes.select()
+async for rows in database.iterate(query=query, n=10):
+    assert 1 <= len(rows) <= 10
     ...
 
 # Close all connection in the connection pool


### PR DESCRIPTION
addresses https://github.com/encode/databases/issues/413, but only for postgres with asyncpg, passing `n` in the kwargs to `.iterate` will error for the other drivers, i can add them eventually if that's a requirement to get this merged

- [x] asyncpg
- [ ] tests
- [ ] other drivers
- [ ] documentation