### PR TITLE
add support for unix domain connection urls

### DIFF
--- a/databases/core.py
+++ b/databases/core.py
@@ -473,7 +473,11 @@ class DatabaseURL:
 
     @property
     def hostname(self) -> typing.Optional[str]:
-        return self.components.hostname
+        return (
+            self.components.hostname
+            or self.options.get("host")
+            or self.options.get("unix_sock")
+        )
 
     @property
     def port(self) -> typing.Optional[int]:

--- a/tests/test_database_url.py
+++ b/tests/test_database_url.py
@@ -29,6 +29,20 @@ def test_database_url_properties():
     assert u.port == 123
     assert u.database == "mydatabase"
 
+    u = DatabaseURL(
+        "postgresql://username:password@/mydatabase?host=/var/run/postgresql/.s.PGSQL.5432"
+    )
+    assert u.dialect == "postgresql"
+    assert u.username == "username"
+    assert u.password == "password"
+    assert u.hostname == "/var/run/postgresql/.s.PGSQL.5432"
+    assert u.database == "mydatabase"
+
+    u = DatabaseURL(
+        "postgresql://username:password@/mydatabase?unix_sock=/var/run/postgresql/.s.PGSQL.5432"
+    )
+    assert u.hostname == "/var/run/postgresql/.s.PGSQL.5432"
+
 
 def test_database_url_escape():
     u = DatabaseURL(f"postgresql://username:{quote('[password')}@localhost/mydatabase")


### PR DESCRIPTION
closes https://github.com/encode/databases/issues/422

unix domain connection urls come in the following format:

```python
"postgresql+psycopg2://user:password@/dbname?host=/var/lib/postgresql" or
"postgresql+psycopg2://user:password@/dbname?unix_sock=/var/lib/postgresql"
```

here we use the options dict to retrieve the hostname