### PR TITLE
Change extra installations to specific drivers

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,18 +32,11 @@ $ pip install databases
 You can install the required database drivers with:
 
 ```shell
-$ pip install databases[postgresql]
-$ pip install databases[mysql]
-$ pip install databases[sqlite]
-```
-
-Default driver support is provided using one of [asyncpg][asyncpg], [aiomysql][aiomysql], or [aiosqlite][aiosqlite].
-
-You can also use other database drivers supported by `databases`:
-
-```shel
-$ pip install databases[postgresql+aiopg]
-$ pip install databases[mysql+asyncmy]
+$ pip install databases[asyncpg]
+$ pip install databases[aiopg]
+$ pip install databases[aiomysql]
+$ pip install databases[asyncmy]
+$ pip install databases[aiosqlite]
 ```
 
 Note that if you are using any synchronous SQLAlchemy functions such as `engine.create_all()` or [alembic][alembic] migrations then you still have to install a synchronous DB driver: [psycopg2][psycopg2] for PostgreSQL and [pymysql][pymysql] for MySQL.
@@ -56,7 +49,7 @@ For this example we'll create a very simple SQLite database to run some
 queries against.
 
 ```shell
-$ pip install databases[sqlite]
+$ pip install databases[aiosqlite]
 $ pip install ipython
 ```
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,14 @@ Databases is suitable for integrating against any async Web framework, such as [
 $ pip install databases
 ```
 
+Database drivers supported are:
+
+* [asyncpg][asyncpg]
+* [aiopg][aiopg]
+* [aiomysql][aiomysql]
+* [asyncmy][asyncmy]
+* [aiosqlite][aiosqlite]
+
 You can install the required database drivers with:
 
 ```shell
@@ -61,7 +69,7 @@ expressions directly from the console.
 ```python
 # Create a database instance, and connect to it.
 from databases import Database
-database = Database('sqlite:///example.db')
+database = Database('sqlite+aiosqlite:///example.db')
 await database.connect()
 
 # Create a table.
@@ -95,6 +103,11 @@ for examples of how to start using databases together with SQLAlchemy core expre
 [alembic]: https://alembic.sqlalchemy.org/en/latest/
 [psycopg2]: https://www.psycopg.org/
 [pymysql]: https://github.com/PyMySQL/PyMySQL
+[asyncpg]: https://github.com/MagicStack/asyncpg
+[aiopg]: https://github.com/aio-libs/aiopg
+[aiomysql]: https://github.com/aio-libs/aiomysql
+[asyncmy]: https://github.com/long2ice/asyncmy
+[aiosqlite]: https://github.com/omnilib/aiosqlite
 
 [starlette]: https://github.com/encode/starlette
 [sanic]: https://github.com/huge-success/sanic

--- a/README.md
+++ b/README.md
@@ -95,9 +95,6 @@ for examples of how to start using databases together with SQLAlchemy core expre
 [alembic]: https://alembic.sqlalchemy.org/en/latest/
 [psycopg2]: https://www.psycopg.org/
 [pymysql]: https://github.com/PyMySQL/PyMySQL
-[asyncpg]: https://github.com/MagicStack/asyncpg
-[aiomysql]: https://github.com/aio-libs/aiomysql
-[aiosqlite]: https://github.com/jreese/aiosqlite
 
 [starlette]: https://github.com/encode/starlette
 [sanic]: https://github.com/huge-success/sanic

--- a/docs/connections_and_transactions.md
+++ b/docs/connections_and_transactions.md
@@ -44,17 +44,17 @@ and for configuring the connection pool.
 
 ```python
 # Use an SSL connection.
-database = Database('postgresql://localhost/example?ssl=true')
+database = Database('postgresql+asyncpg://localhost/example?ssl=true')
 
 # Use a connection pool of between 5-20 connections.
-database = Database('mysql://localhost/example?min_size=5&max_size=20')
+database = Database('mysql+aiomysql://localhost/example?min_size=5&max_size=20')
 ```
 
 You can also use keyword arguments to pass in any connection options.
 Available keyword arguments may differ between database backends.
 
 ```python
-database = Database('postgresql://localhost/example', ssl=True, min_size=5, max_size=20)
+database = Database('postgresql+asyncpg://localhost/example', ssl=True, min_size=5, max_size=20)
 ```
 
 ## Transactions

--- a/docs/database_queries.md
+++ b/docs/database_queries.md
@@ -34,7 +34,7 @@ You can now use any [SQLAlchemy core][sqlalchemy-core] queries ([official tutori
 ```python
 from databases import Database
 
-database = Database('postgresql://localhost/example')
+database = Database('postgresql+asyncpg://localhost/example')
 
 
 # Establish the connection pool

--- a/docs/index.md
+++ b/docs/index.md
@@ -27,6 +27,14 @@ Databases is suitable for integrating against any async Web framework, such as [
 $ pip install databases
 ```
 
+Database drivers supported are:
+
+* [asyncpg][asyncpg]
+* [aiopg][aiopg]
+* [aiomysql][aiomysql]
+* [asyncmy][asyncmy]
+* [aiosqlite][aiosqlite]
+
 You can install the required database drivers with:
 
 ```shell
@@ -59,7 +67,7 @@ expressions directly from the console.
 ```python
 # Create a database instance, and connect to it.
 from databases import Database
-database = Database('sqlite:///example.db')
+database = Database('sqlite+aiosqlite:///example.db')
 await database.connect()
 
 # Create a table.
@@ -93,6 +101,11 @@ for examples of how to start using databases together with SQLAlchemy core expre
 [alembic]: https://alembic.sqlalchemy.org/en/latest/
 [psycopg2]: https://www.psycopg.org/
 [pymysql]: https://github.com/PyMySQL/PyMySQL
+[asyncpg]: https://github.com/MagicStack/asyncpg
+[aiopg]: https://github.com/aio-libs/aiopg
+[aiomysql]: https://github.com/aio-libs/aiomysql
+[asyncmy]: https://github.com/long2ice/asyncmy
+[aiosqlite]: https://github.com/omnilib/aiosqlite
 
 [starlette]: https://github.com/encode/starlette
 [sanic]: https://github.com/huge-success/sanic

--- a/docs/index.md
+++ b/docs/index.md
@@ -93,9 +93,6 @@ for examples of how to start using databases together with SQLAlchemy core expre
 [alembic]: https://alembic.sqlalchemy.org/en/latest/
 [psycopg2]: https://www.psycopg.org/
 [pymysql]: https://github.com/PyMySQL/PyMySQL
-[asyncpg]: https://github.com/MagicStack/asyncpg
-[aiomysql]: https://github.com/aio-libs/aiomysql
-[aiosqlite]: https://github.com/jreese/aiosqlite
 
 [starlette]: https://github.com/encode/starlette
 [sanic]: https://github.com/huge-success/sanic

--- a/docs/index.md
+++ b/docs/index.md
@@ -30,18 +30,11 @@ $ pip install databases
 You can install the required database drivers with:
 
 ```shell
-$ pip install databases[postgresql]
-$ pip install databases[mysql]
-$ pip install databases[sqlite]
-```
-
-Default driver support is provided using one of [asyncpg][asyncpg], [aiomysql][aiomysql], or [aiosqlite][aiosqlite].
-
-You can also use other database drivers supported by `databases`:
-
-```shel
-$ pip install databases[postgresql+aiopg]
-$ pip install databases[mysql+asyncmy]
+$ pip install databases[asyncpg]
+$ pip install databases[aiopg]
+$ pip install databases[aiomysql]
+$ pip install databases[asyncmy]
+$ pip install databases[aiosqlite]
 ```
 
 Note that if you are using any synchronous SQLAlchemy functions such as `engine.create_all()` or [alembic][alembic] migrations then you still have to install a synchronous DB driver: [psycopg2][psycopg2] for PostgreSQL and [pymysql][pymysql] for MySQL.
@@ -54,7 +47,7 @@ For this example we'll create a very simple SQLite database to run some
 queries against.
 
 ```shell
-$ pip install databases[sqlite]
+$ pip install databases[aiosqlite]
 $ pip install ipython
 ```
 

--- a/setup.py
+++ b/setup.py
@@ -50,10 +50,13 @@ setup(
     install_requires=["sqlalchemy>=1.4,<1.5", 'aiocontextvars;python_version<"3.7"'],
     extras_require={
         "postgresql": ["asyncpg"],
+        "asyncpg": ["asyncpg"],
+        "aiopg": ["aiopg"],
         "mysql": ["aiomysql"],
-        "mysql+asyncmy": ["asyncmy"],
+        "aiomysql": ["aiomysql"],
+        "asyncmy": ["asyncmy"],
         "sqlite": ["aiosqlite"],
-        "postgresql+aiopg": ["aiopg"],
+        "aiosqlite": ["aiosqlite"],
     },
     classifiers=[
         "Development Status :: 3 - Alpha",


### PR DESCRIPTION
Closes #429 and closes #421.

Changes extra installations from:

```shell
pip install databases[postgresql+asyncpg]
```

To:

```shell
pip install databases[asyncpg]
```

This will be a step towards downplaying the default drivers.
Even though it keeps default drivers to work like `pip install databases[postgresql]` but will remove them from the docs to point to specific drivers.

And also worth mentioning that this will be the API, still mentioned the default in the docs:

```python
database = Database('sqlite:///example.db')
```

This is equivalent to:

```python
database = Database('sqlite+aiosqlite:///example.db')
```

I think we should also downplay the default dialect and specify the driver in the docs.
