### PR TITLE
Add _mapping property to the result set interface.

### DIFF
--- a/databases/backends/aiopg.py
+++ b/databases/backends/aiopg.py
@@ -14,7 +14,7 @@ from sqlalchemy.sql import ClauseElement
 from sqlalchemy.sql.ddl import DDLElement
 
 from databases.core import DatabaseURL
-from databases.interfaces import ConnectionBackend, DatabaseBackend, TransactionBackend
+from databases.interfaces import ConnectionBackend, DatabaseBackend, TransactionBackend, Record
 
 logger = logging.getLogger("databases")
 
@@ -112,7 +112,7 @@ class AiopgConnection(ConnectionBackend):
         await self._database._pool.release(self._connection)
         self._connection = None
 
-    async def fetch_all(self, query: ClauseElement) -> typing.List[typing.Sequence]:
+    async def fetch_all(self, query: ClauseElement) -> typing.List[Record]:
         assert self._connection is not None, "Connection is not acquired"
         query_str, args, context = self._compile(query)
         cursor = await self._connection.cursor()
@@ -133,7 +133,7 @@ class AiopgConnection(ConnectionBackend):
         finally:
             cursor.close()
 
-    async def fetch_one(self, query: ClauseElement) -> typing.Optional[typing.Sequence]:
+    async def fetch_one(self, query: ClauseElement) -> typing.Optional[Record]:
         assert self._connection is not None, "Connection is not acquired"
         query_str, args, context = self._compile(query)
         cursor = await self._connection.cursor()

--- a/databases/backends/aiopg.py
+++ b/databases/backends/aiopg.py
@@ -14,7 +14,12 @@ from sqlalchemy.sql import ClauseElement
 from sqlalchemy.sql.ddl import DDLElement
 
 from databases.core import DatabaseURL
-from databases.interfaces import ConnectionBackend, DatabaseBackend, TransactionBackend, Record
+from databases.interfaces import (
+    ConnectionBackend,
+    DatabaseBackend,
+    Record,
+    TransactionBackend,
+)
 
 logger = logging.getLogger("databases")
 

--- a/databases/backends/asyncmy.py
+++ b/databases/backends/asyncmy.py
@@ -12,7 +12,12 @@ from sqlalchemy.sql import ClauseElement
 from sqlalchemy.sql.ddl import DDLElement
 
 from databases.core import LOG_EXTRA, DatabaseURL
-from databases.interfaces import ConnectionBackend, DatabaseBackend, TransactionBackend, Record
+from databases.interfaces import (
+    ConnectionBackend,
+    DatabaseBackend,
+    Record,
+    TransactionBackend,
+)
 
 logger = logging.getLogger("databases")
 

--- a/databases/backends/asyncmy.py
+++ b/databases/backends/asyncmy.py
@@ -12,7 +12,7 @@ from sqlalchemy.sql import ClauseElement
 from sqlalchemy.sql.ddl import DDLElement
 
 from databases.core import LOG_EXTRA, DatabaseURL
-from databases.interfaces import ConnectionBackend, DatabaseBackend, TransactionBackend
+from databases.interfaces import ConnectionBackend, DatabaseBackend, TransactionBackend, Record
 
 logger = logging.getLogger("databases")
 
@@ -100,7 +100,7 @@ class AsyncMyConnection(ConnectionBackend):
         await self._database._pool.release(self._connection)
         self._connection = None
 
-    async def fetch_all(self, query: ClauseElement) -> typing.List[typing.Sequence]:
+    async def fetch_all(self, query: ClauseElement) -> typing.List[Record]:
         assert self._connection is not None, "Connection is not acquired"
         query_str, args, context = self._compile(query)
         async with self._connection.cursor() as cursor:
@@ -121,7 +121,7 @@ class AsyncMyConnection(ConnectionBackend):
             finally:
                 await cursor.close()
 
-    async def fetch_one(self, query: ClauseElement) -> typing.Optional[typing.Sequence]:
+    async def fetch_one(self, query: ClauseElement) -> typing.Optional[Record]:
         assert self._connection is not None, "Connection is not acquired"
         query_str, args, context = self._compile(query)
         async with self._connection.cursor() as cursor:

--- a/databases/backends/mysql.py
+++ b/databases/backends/mysql.py
@@ -12,7 +12,7 @@ from sqlalchemy.sql import ClauseElement
 from sqlalchemy.sql.ddl import DDLElement
 
 from databases.core import LOG_EXTRA, DatabaseURL
-from databases.interfaces import ConnectionBackend, DatabaseBackend, TransactionBackend
+from databases.interfaces import ConnectionBackend, DatabaseBackend, TransactionBackend, Record
 
 logger = logging.getLogger("databases")
 
@@ -100,7 +100,7 @@ class MySQLConnection(ConnectionBackend):
         await self._database._pool.release(self._connection)
         self._connection = None
 
-    async def fetch_all(self, query: ClauseElement) -> typing.List[typing.Sequence]:
+    async def fetch_all(self, query: ClauseElement) -> typing.List[Record]:
         assert self._connection is not None, "Connection is not acquired"
         query_str, args, context = self._compile(query)
         cursor = await self._connection.cursor()
@@ -121,7 +121,7 @@ class MySQLConnection(ConnectionBackend):
         finally:
             await cursor.close()
 
-    async def fetch_one(self, query: ClauseElement) -> typing.Optional[typing.Sequence]:
+    async def fetch_one(self, query: ClauseElement) -> typing.Optional[Record]:
         assert self._connection is not None, "Connection is not acquired"
         query_str, args, context = self._compile(query)
         cursor = await self._connection.cursor()

--- a/databases/backends/mysql.py
+++ b/databases/backends/mysql.py
@@ -12,7 +12,12 @@ from sqlalchemy.sql import ClauseElement
 from sqlalchemy.sql.ddl import DDLElement
 
 from databases.core import LOG_EXTRA, DatabaseURL
-from databases.interfaces import ConnectionBackend, DatabaseBackend, TransactionBackend, Record
+from databases.interfaces import (
+    ConnectionBackend,
+    DatabaseBackend,
+    Record,
+    TransactionBackend,
+)
 
 logger = logging.getLogger("databases")
 

--- a/databases/backends/postgres.py
+++ b/databases/backends/postgres.py
@@ -83,7 +83,7 @@ class PostgresBackend(DatabaseBackend):
         return PostgresConnection(self, self._dialect)
 
 
-class Record(Sequence):
+class Record(RecordInterface):
     __slots__ = (
         "_row",
         "_result_columns",
@@ -110,7 +110,7 @@ class Record(Sequence):
         self._column_map, self._column_map_int, self._column_map_full = column_maps
 
     @property
-    def _mapping(self) -> asyncpg.Record:
+    def _mapping(self) -> typing.Mapping:
         return self._row
 
     def keys(self) -> typing.KeysView:

--- a/databases/backends/postgres.py
+++ b/databases/backends/postgres.py
@@ -11,7 +11,12 @@ from sqlalchemy.sql.schema import Column
 from sqlalchemy.types import TypeEngine
 
 from databases.core import LOG_EXTRA, DatabaseURL
-from databases.interfaces import ConnectionBackend, DatabaseBackend, TransactionBackend, Record as RecordInterface
+from databases.interfaces import (
+    ConnectionBackend,
+    DatabaseBackend,
+    Record as RecordInterface,
+    TransactionBackend,
+)
 
 logger = logging.getLogger("databases")
 

--- a/databases/backends/postgres.py
+++ b/databases/backends/postgres.py
@@ -11,7 +11,7 @@ from sqlalchemy.sql.schema import Column
 from sqlalchemy.types import TypeEngine
 
 from databases.core import LOG_EXTRA, DatabaseURL
-from databases.interfaces import ConnectionBackend, DatabaseBackend, TransactionBackend
+from databases.interfaces import ConnectionBackend, DatabaseBackend, TransactionBackend, Record as RecordInterface
 
 logger = logging.getLogger("databases")
 
@@ -168,7 +168,7 @@ class PostgresConnection(ConnectionBackend):
         self._connection = await self._database._pool.release(self._connection)
         self._connection = None
 
-    async def fetch_all(self, query: ClauseElement) -> typing.List[typing.Sequence]:
+    async def fetch_all(self, query: ClauseElement) -> typing.List[RecordInterface]:
         assert self._connection is not None, "Connection is not acquired"
         query_str, args, result_columns = self._compile(query)
         rows = await self._connection.fetch(query_str, *args)
@@ -176,7 +176,7 @@ class PostgresConnection(ConnectionBackend):
         column_maps = self._create_column_maps(result_columns)
         return [Record(row, result_columns, dialect, column_maps) for row in rows]
 
-    async def fetch_one(self, query: ClauseElement) -> typing.Optional[typing.Sequence]:
+    async def fetch_one(self, query: ClauseElement) -> typing.Optional[RecordInterface]:
         assert self._connection is not None, "Connection is not acquired"
         query_str, args, result_columns = self._compile(query)
         row = await self._connection.fetchrow(query_str, *args)

--- a/databases/backends/sqlite.py
+++ b/databases/backends/sqlite.py
@@ -11,7 +11,7 @@ from sqlalchemy.sql import ClauseElement
 from sqlalchemy.sql.ddl import DDLElement
 
 from databases.core import LOG_EXTRA, DatabaseURL
-from databases.interfaces import ConnectionBackend, DatabaseBackend, TransactionBackend
+from databases.interfaces import ConnectionBackend, DatabaseBackend, TransactionBackend, Record
 
 logger = logging.getLogger("databases")
 
@@ -86,7 +86,7 @@ class SQLiteConnection(ConnectionBackend):
         await self._pool.release(self._connection)
         self._connection = None
 
-    async def fetch_all(self, query: ClauseElement) -> typing.List[typing.Sequence]:
+    async def fetch_all(self, query: ClauseElement) -> typing.List[Record]:
         assert self._connection is not None, "Connection is not acquired"
         query_str, args, context = self._compile(query)
 
@@ -104,7 +104,7 @@ class SQLiteConnection(ConnectionBackend):
                 for row in rows
             ]
 
-    async def fetch_one(self, query: ClauseElement) -> typing.Optional[typing.Sequence]:
+    async def fetch_one(self, query: ClauseElement) -> typing.Optional[Record]:
         assert self._connection is not None, "Connection is not acquired"
         query_str, args, context = self._compile(query)
 

--- a/databases/backends/sqlite.py
+++ b/databases/backends/sqlite.py
@@ -11,7 +11,12 @@ from sqlalchemy.sql import ClauseElement
 from sqlalchemy.sql.ddl import DDLElement
 
 from databases.core import LOG_EXTRA, DatabaseURL
-from databases.interfaces import ConnectionBackend, DatabaseBackend, TransactionBackend, Record
+from databases.interfaces import (
+    ConnectionBackend,
+    DatabaseBackend,
+    Record,
+    TransactionBackend,
+)
 
 logger = logging.getLogger("databases")
 

--- a/databases/core.py
+++ b/databases/core.py
@@ -11,7 +11,7 @@ from sqlalchemy import text
 from sqlalchemy.sql import ClauseElement
 
 from databases.importer import import_from_string
-from databases.interfaces import ConnectionBackend, DatabaseBackend, TransactionBackend
+from databases.interfaces import ConnectionBackend, DatabaseBackend, TransactionBackend, Record
 
 if sys.version_info >= (3, 7):  # pragma: no cover
     import contextvars as contextvars
@@ -144,13 +144,13 @@ class Database:
 
     async def fetch_all(
         self, query: typing.Union[ClauseElement, str], values: dict = None
-    ) -> typing.List[typing.Sequence]:
+    ) -> typing.List[Record]:
         async with self.connection() as connection:
             return await connection.fetch_all(query, values)
 
     async def fetch_one(
         self, query: typing.Union[ClauseElement, str], values: dict = None
-    ) -> typing.Optional[typing.Sequence]:
+    ) -> typing.Optional[Record]:
         async with self.connection() as connection:
             return await connection.fetch_one(query, values)
 
@@ -265,14 +265,14 @@ class Connection:
 
     async def fetch_all(
         self, query: typing.Union[ClauseElement, str], values: dict = None
-    ) -> typing.List[typing.Sequence]:
+    ) -> typing.List[Record]:
         built_query = self._build_query(query, values)
         async with self._query_lock:
             return await self._connection.fetch_all(built_query)
 
     async def fetch_one(
         self, query: typing.Union[ClauseElement, str], values: dict = None
-    ) -> typing.Optional[typing.Sequence]:
+    ) -> typing.Optional[Record]:
         built_query = self._build_query(query, values)
         async with self._query_lock:
             return await self._connection.fetch_one(built_query)

--- a/databases/core.py
+++ b/databases/core.py
@@ -11,7 +11,12 @@ from sqlalchemy import text
 from sqlalchemy.sql import ClauseElement
 
 from databases.importer import import_from_string
-from databases.interfaces import ConnectionBackend, DatabaseBackend, TransactionBackend, Record
+from databases.interfaces import (
+    ConnectionBackend,
+    DatabaseBackend,
+    Record,
+    TransactionBackend,
+)
 
 if sys.version_info >= (3, 7):  # pragma: no cover
     import contextvars as contextvars

--- a/databases/interfaces.py
+++ b/databases/interfaces.py
@@ -1,4 +1,5 @@
 import typing
+from collections.abc import Sequence
 
 from sqlalchemy.sql import ClauseElement
 
@@ -21,10 +22,10 @@ class ConnectionBackend:
     async def release(self) -> None:
         raise NotImplementedError()  # pragma: no cover
 
-    async def fetch_all(self, query: ClauseElement) -> typing.List[typing.Sequence]:
+    async def fetch_all(self, query: ClauseElement) -> typing.List['Record']:
         raise NotImplementedError()  # pragma: no cover
 
-    async def fetch_one(self, query: ClauseElement) -> typing.Optional[typing.Sequence]:
+    async def fetch_one(self, query: ClauseElement) -> typing.Optional['Record']:
         raise NotImplementedError()  # pragma: no cover
 
     async def fetch_val(
@@ -65,4 +66,10 @@ class TransactionBackend:
         raise NotImplementedError()  # pragma: no cover
 
     async def rollback(self) -> None:
+        raise NotImplementedError()  # pragma: no cover
+
+
+class Record(Sequence):
+    @property
+    def _mapping(self) -> typing.Mapping:
         raise NotImplementedError()  # pragma: no cover

--- a/databases/interfaces.py
+++ b/databases/interfaces.py
@@ -22,10 +22,10 @@ class ConnectionBackend:
     async def release(self) -> None:
         raise NotImplementedError()  # pragma: no cover
 
-    async def fetch_all(self, query: ClauseElement) -> typing.List['Record']:
+    async def fetch_all(self, query: ClauseElement) -> typing.List["Record"]:
         raise NotImplementedError()  # pragma: no cover
 
-    async def fetch_one(self, query: ClauseElement) -> typing.Optional['Record']:
+    async def fetch_one(self, query: ClauseElement) -> typing.Optional["Record"]:
         raise NotImplementedError()  # pragma: no cover
 
     async def fetch_val(

--- a/docs/database_queries.md
+++ b/docs/database_queries.md
@@ -108,3 +108,20 @@ Note that query arguments should follow the `:query_arg` style.
 
 [sqlalchemy-core]: https://docs.sqlalchemy.org/en/latest/core/
 [sqlalchemy-core-tutorial]: https://docs.sqlalchemy.org/en/latest/core/tutorial.html
+
+## Query result
+
+To keep in line with [SQLAlchemy 1.4 changes][sqlalchemy-mapping-changes] 
+query result object no longer implements a mapping interface. 
+To access query result as a mapping you should use the `_mapping` property. 
+That way you can process both SQLAlchemy Rows and databases Records from raw queries 
+with the same function without any instance checks.
+
+```python
+query = "SELECT * FROM notes WHERE id = :id"
+result = await database.fetch_one(query=query, values={"id": 1})
+result.id  # access field via attribute
+result._mapping['id']  # access field via mapping
+```
+
+[sqlalchemy-mapping-changes]: https://docs.sqlalchemy.org/en/14/changelog/migration_14.html#rowproxy-is-no-longer-a-proxy-is-now-called-row-and-behaves-like-an-enhanced-named-tuple

--- a/tests/test_databases.py
+++ b/tests/test_databases.py
@@ -1206,3 +1206,25 @@ async def test_postcompile_queries(database_url):
         results = await database.fetch_all(query=query)
 
         assert len(results) == 0
+
+
+@pytest.mark.parametrize("database_url", DATABASE_URLS)
+@mysql_versions
+@async_adapter
+async def test_mapping_property_interface(database_url):
+    """
+    Test that all connections implements interface with `_mapping` property
+    """
+    async with Database(database_url) as database:
+        query = notes.insert()
+        values = {"text": "example1", "completed": True}
+        await database.execute(query, values)
+
+        query = notes.select()
+        single_result = await database.fetch_one(query=query)
+        assert single_result._mapping["text"] == "example1"
+        assert single_result._mapping["completed"] is True
+
+        list_result = await database.fetch_all(query=query)
+        assert list_result[0]._mapping["text"] == "example1"
+        assert list_result[0]._mapping["completed"] is True

--- a/tests/test_databases.py
+++ b/tests/test_databases.py
@@ -1211,40 +1211,14 @@ async def test_postcompile_queries(database_url):
 @pytest.mark.parametrize("database_url", DATABASE_URLS)
 @mysql_versions
 @async_adapter
-async def test_mapping_property_interface(database_url):
-    """
-    Test that all connections implements interface with `_mapping` property
-    """
+async def test_result_named_access(database_url):
     async with Database(database_url) as database:
         query = notes.insert()
         values = {"text": "example1", "completed": True}
         await database.execute(query, values)
-        
-        query = notes.select()
-        single_result = await database.fetch_one(query=query)
-        assert single_result._mapping["text"] == "example1"
-        assert single_result._mapping["completed"] is True
 
-        list_result = await database.fetch_all(query=query)
-        assert list_result[0]._mapping["text"] == "example1"
-        assert list_result[0]._mapping["completed"] is True
-
-        
-@pytest.mark.parametrize("database_url", DATABASE_URLS)
-@mysql_versions
-@async_adapter
-async def test_result_named_access(database_url):
-    """
-    Test attribute access of result columns
-    """
-    async with Database(database_url) as database:
-        query = notes.insert()
-        values = {"text": "example1", "completed": True}
-        await database.execute(query, values)      
-        
         query = notes.select().where(notes.c.text == "example1")
         result = await database.fetch_one(query=query)
 
         assert result.text == "example1"
         assert result.completed is True
-

--- a/tests/test_databases.py
+++ b/tests/test_databases.py
@@ -1222,3 +1222,25 @@ async def test_result_named_access(database_url):
 
         assert result.text == "example1"
         assert result.completed is True
+
+
+@pytest.mark.parametrize("database_url", DATABASE_URLS)
+@mysql_versions
+@async_adapter
+async def test_mapping_property_interface(database_url):
+    """
+    Test that all connections implements interface with `_mapping` property
+    """
+    async with Database(database_url) as database:
+        query = notes.insert()
+        values = {"text": "example1", "completed": True}
+        await database.execute(query, values)
+
+        query = notes.select()
+        single_result = await database.fetch_one(query=query)
+        assert single_result._mapping["text"] == "example1"
+        assert single_result._mapping["completed"] is True
+
+        list_result = await database.fetch_all(query=query)
+        assert list_result[0]._mapping["text"] == "example1"
+        assert list_result[0]._mapping["completed"] is True

--- a/tests/test_databases.py
+++ b/tests/test_databases.py
@@ -1229,7 +1229,7 @@ async def test_result_named_access(database_url):
 @async_adapter
 async def test_mapping_property_interface(database_url):
     """
-    Test that all connections implements interface with `_mapping` property
+    Test that all connections implement interface with `_mapping` property
     """
     async with Database(database_url) as database:
         query = notes.insert()


### PR DESCRIPTION
Closes #445 

As discussed in the main issue i've added `_mapping` property to the result set interface. Both asyncpg Record and sqlalchemy Row have this property so it's safe to add it.
