### PR TITLE
Fix query result named access

### DIFF
--- a/databases/backends/postgres.py
+++ b/databases/backends/postgres.py
@@ -150,6 +150,9 @@ class Record(Sequence):
     def __len__(self) -> int:
         return len(self._row)
 
+    def __getattr__(self, name: str) -> typing.Any:
+        return self._mapping.get(name)
+
 
 class PostgresConnection(ConnectionBackend):
     def __init__(self, database: PostgresBackend, dialect: Dialect):

--- a/tests/test_databases.py
+++ b/tests/test_databases.py
@@ -1206,3 +1206,19 @@ async def test_postcompile_queries(database_url):
         results = await database.fetch_all(query=query)
 
         assert len(results) == 0
+
+
+@pytest.mark.parametrize("database_url", DATABASE_URLS)
+@mysql_versions
+@async_adapter
+async def test_result_named_access(database_url):
+    async with Database(database_url) as database:
+        query = notes.insert()
+        values = {"text": "example1", "completed": True}
+        await database.execute(query, values)
+
+        query = notes.select().where(notes.c.text == "example1")
+        result = await database.fetch_one(query=query)
+
+        assert result.text == "example1"
+        assert result.completed is True


### PR DESCRIPTION
The SQLAlchemy `Row` already implements `__getattr__` through `BaseRow` so if we add it to asyncpg `Record` then it should be ok for all drivers.