### PR TITLE
Open up SQLite query param, cached database functionality, inspired by #196

### DIFF
--- a/databases/backends/sqlite.py
+++ b/databases/backends/sqlite.py
@@ -1,6 +1,8 @@
 import logging
+import sqlite3
 import typing
 import uuid
+from urllib.parse import urlencode
 
 import aiosqlite
 from sqlalchemy.dialects.sqlite import pysqlite
@@ -40,7 +42,9 @@ class SQLiteBackend(DatabaseBackend):
         # )
 
     async def disconnect(self) -> None:
-        pass
+        # remove reference to cached database connection on disconnect
+        if self._pool._memref:
+            self._pool._memref = None
         # assert self._pool is not None, "DatabaseBackend is not running"
         # self._pool.close()
         # await self._pool.wait_closed()
@@ -52,12 +56,19 @@ class SQLiteBackend(DatabaseBackend):
 
 class SQLitePool:
     def __init__(self, url: DatabaseURL, **options: typing.Any) -> None:
-        self._url = url
+        self._database = url.database
+        self._memref = None
+        if url.options:
+            self._database += "?" + urlencode(url.options)
         self._options = options
+
+        if url.options and "cache" in url.options:
+            # reference to cached memory database must be held to keep it from being deleted
+            self._memref = sqlite3.connect(self._database, **self._options)
 
     async def acquire(self) -> aiosqlite.Connection:
         connection = aiosqlite.connect(
-            database=self._url.database, isolation_level=None, **self._options
+            database=self._database, isolation_level=None, **self._options
         )
         await connection.__aenter__()
         return connection

--- a/databases/backends/sqlite.py
+++ b/databases/backends/sqlite.py
@@ -58,6 +58,7 @@ class SQLitePool:
     def __init__(self, url: DatabaseURL, **options: typing.Any) -> None:
         self._database = url.database
         self._memref = None
+        # add query params to database connection string
         if url.options:
             self._database += "?" + urlencode(url.options)
         self._options = options

--- a/databases/backends/sqlite.py
+++ b/databases/backends/sqlite.py
@@ -42,7 +42,7 @@ class SQLiteBackend(DatabaseBackend):
         # )
 
     async def disconnect(self) -> None:
-        # remove reference to cached database connection on disconnect
+        # if it extsis, remove reference to connection to cached in-memory database on disconnect
         if self._pool._memref:
             self._pool._memref = None
         # assert self._pool is not None, "DatabaseBackend is not running"
@@ -64,7 +64,7 @@ class SQLitePool:
         self._options = options
 
         if url.options and "cache" in url.options:
-            # reference to cached memory database must be held to keep it from being deleted
+            # reference to a connection to the cached in-memory database must be held to keep it from being deleted
             self._memref = sqlite3.connect(self._database, **self._options)
 
     async def acquire(self) -> aiosqlite.Connection:

--- a/tests/test_databases.py
+++ b/tests/test_databases.py
@@ -4,6 +4,7 @@ import decimal
 import functools
 import os
 import re
+import sqlite3
 import sys
 from unittest.mock import MagicMock, patch
 
@@ -1222,3 +1223,47 @@ async def test_result_named_access(database_url):
 
         assert result.text == "example1"
         assert result.completed is True
+
+
+@async_adapter
+async def test_should_not_maintain_ref_when_no_cache_param():
+    async with Database("sqlite:///file::memory:", uri=True) as database:
+        query = sqlalchemy.schema.CreateTable(notes)
+        await database.execute(query)
+
+        query = notes.insert()
+        values = {"text": "example1", "completed": True}
+        with pytest.raises(sqlite3.OperationalError):
+            await database.execute(query, values)
+
+
+@async_adapter
+async def test_should_maintain_ref_when_cache_param():
+    async with Database("sqlite:///file::memory:?cache=shared", uri=True) as database:
+        query = sqlalchemy.schema.CreateTable(notes)
+        await database.execute(query)
+
+        query = notes.insert()
+        values = {"text": "example1", "completed": True}
+        await database.execute(query, values)
+
+        query = notes.select().where(notes.c.text == "example1")
+        result = await database.fetch_one(query=query)
+        assert result.text == "example1"
+        assert result.completed is True
+
+
+@async_adapter
+async def test_should_remove_ref_on_disconnect():
+    async with Database("sqlite:///file::memory:?cache=shared", uri=True) as database:
+        query = sqlalchemy.schema.CreateTable(notes)
+        await database.execute(query)
+
+        query = notes.insert()
+        values = {"text": "example1", "completed": True}
+        await database.execute(query, values)
+
+    async with Database("sqlite:///file::memory:?cache=shared", uri=True) as database:
+        query = notes.select()
+        with pytest.raises(sqlite3.OperationalError):
+            await database.fetch_all(query=query)


### PR DESCRIPTION
## Background
In sqlite3, if you set `uri=True` you can pass query param arguments to the underlying database, including:

- `mode = memory, ro, rw`
- `cache = shared`

Examples:
```python
# Open a database in read-only mode.
con = sqlite3.connect("file:template.db?mode=ro", uri=True)

# Don't implicitly create a new database file if it does not already exist.
# Will raise sqlite3.OperationalError if unable to open a database file.
con = sqlite3.connect("file:nosuchdb.db?mode=rw", uri=True)

# Create a cached in-memory database.
con = sqlite3.connect("file::memory:?cache=shared", uri=True)

# Create independent named in-memory database.
con1 = sqlite3.connect("file:mem1?mode=memory&cache=shared", uri=True)
con2 = sqlite3.connect("file:mem2?mode=memory&cache=shared", uri=True)
```
Options like `cache=shared` and `mode=memory` are particularly useful for unit testing (you can create an in-memory DB which stays alive between multiple connections).

## The Issue
The issue is twofold: 

1. `databases` strips out query params before passing the connection  string to underling connection
2. `databases` closing the db connection after each query means that there is no living reference to a connection of the cached in-memory database once the query finishes. This causes the cached in-memory database to be deleted after each query even if we could set `cache=shared`

This leads to the following behavior:

```python
import asyncio
import sqlite3

from databases import Database

async def example():
    database = Database("sqlite:///file::memory:?cache=shared", uri=True)
    await database.connect()
    await database.execute("CREATE TABLE Example(id INT)")
    rows = await database.fetch_all("SELECT * FROM Example") # throws sqlite3.OperationalError: no such table: Example

asyncio.run(example())
```

## Proposed Solution
```diff
diff --git a/databases/backends/sqlite.py b/databases/backends/sqlite.py
index 46a3951..6335465 100644
--- a/databases/backends/sqlite.py
+++ b/databases/backends/sqlite.py
@@ -1,6 +1,8 @@
 import logging
+import sqlite3
 import typing
 import uuid
+from urllib.parse import urlencode
 
 import aiosqlite
 from sqlalchemy.dialects.sqlite import pysqlite
@@ -40,7 +42,9 @@ class SQLiteBackend(DatabaseBackend):
         # )
 
     async def disconnect(self) -> None:
-        pass
+        # if it extsis, remove reference to connection to cached in-memory database on disconnect
+        if self._pool._memref:
+            self._pool._memref = None
         # assert self._pool is not None, "DatabaseBackend is not running"
         # self._pool.close()
         # await self._pool.wait_closed()
@@ -52,12 +56,20 @@ class SQLiteBackend(DatabaseBackend):
 
 class SQLitePool:
     def __init__(self, url: DatabaseURL, **options: typing.Any) -> None:
-        self._url = url
+        self._database = url.database
+        self._memref = None
+        # add query params to database connection string
+        if url.options:
+            self._database += "?" + urlencode(url.options)
         self._options = options
 
+        if url.options and "cache" in url.options:
+            # reference to a connection to the cached in-memory database must be held to keep it from being deleted
+            self._memref = sqlite3.connect(self._database, **self._options)
+
     async def acquire(self) -> aiosqlite.Connection:
         connection = aiosqlite.connect(
-            database=self._url.database, isolation_level=None, **self._options
+            database=self._database, isolation_level=None, **self._options
         )
         await connection.__aenter__()
         return connection
```

This allows query params to be passed to the underlying connection and, when `cache=shared`, a reference to a connection to the cached in-memory database to be held (allowing it to persist) until `Database.disconnect` is called, leading to the following good behavior: 

```python
import asyncio
import sqlite3

from databases import Database

async def example():
    database = Database("sqlite:///file::memory:?cache=shared", uri=True)
    await database.connect()
    await database.execute("CREATE TABLE Example(id INT)")
    rows = await database.fetch_all("SELECT * FROM Example") #no error
    datbase.disconnect()

    database = Database("sqlite:///file::memory:?cache=shared", uri=True)
    await database.connect()
    rows = await database.fetch_all("SELECT * FROM Example") # throws sqlite3.OperationalError: no such table: Example

asyncio.run(example())
```

Also fixes: #196, #75 