### PR TITLE
Depend on sqlalchemy[asyncio] instead of just sqlalchemy

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup(
     author_email="tom@tomchristie.com",
     packages=get_packages("databases"),
     package_data={"databases": ["py.typed"]},
-    install_requires=["sqlalchemy>=1.4,<1.5", 'aiocontextvars;python_version<"3.7"'],
+    install_requires=["sqlalchemy[asyncio]>=1.4,<1.5", 'aiocontextvars;python_version<"3.7"'],
     extras_require={
         "postgresql": ["asyncpg"],
         "asyncpg": ["asyncpg"],


### PR DESCRIPTION
Adding the `asyncio` extra ensures all dependencies for async APIs are required on all platforms.

Fixes #469.