### PR TITLE
Fix postgres KeyError with missing explicit columns (#190)

### DIFF
--- a/databases/backends/postgres.py
+++ b/databases/backends/postgres.py
@@ -140,7 +140,10 @@ class Record(RecordInterface):
         elif isinstance(key, int):
             idx, datatype = self._column_map_int[key]
         else:
-            idx, datatype = self._column_map[key]
+            try:
+                idx, datatype = self._column_map[key]
+            except KeyError:
+                return self._row[key]
         raw = self._row[idx]
         processor = datatype._cached_result_processor(self._dialect, None)
 

--- a/tests/test_databases.py
+++ b/tests/test_databases.py
@@ -225,6 +225,24 @@ async def test_queries(database_url):
 @pytest.mark.parametrize("database_url", DATABASE_URLS)
 @mysql_versions
 @async_adapter
+async def test_queries_manual(database_url):
+    async with Database(database_url) as database:
+        async with database.transaction(force_rollback=True):
+            _t = sqlalchemy.sql.text
+
+            query = notes.insert()
+            values = {"text": "example1", "completed": True}
+            await database.execute(query, values)
+
+            query = sqlalchemy.select([_t("n.text")], from_obj=[_t("notes n")])
+            result = await database.fetch_one(query)
+
+            assert dict(result)
+
+
+@pytest.mark.parametrize("database_url", DATABASE_URLS)
+@mysql_versions
+@async_adapter
 async def test_queries_raw(database_url):
     """
     Test that the basic `execute()`, `execute_many()`, `fetch_all()``, and


### PR DESCRIPTION
If no explicit colum info is present, the postgres Record class causes a
KeyError. Besides the given example in encode/databases#190 this also
happens if you construct the queries from text-clauses.

Handling this the same way as if there is no entry in `self._column_map`
fixes the error.

A simple testcase is added as well.

I did a simple test run using sqlite and postgres.