### PR TITLE
Adding more to decorator docs

### DIFF
--- a/docs/connections_and_transactions.md
+++ b/docs/connections_and_transactions.md
@@ -95,6 +95,17 @@ async def create_users(request):
     ...
 ```
 
+When using with other decorators (such as route decorator `@router.post("")`
+from FastAPI), try to put `@database.transaction()` right above the function
+signature to ensure the automatic transaction management to be applied:
+
+```python
+@router.post("/my-awesome-endpoint")
+@database.transaction()
+async def awesome_endpoint():
+    ...
+```
+
 Transaction blocks are managed as task-local state. Nested transactions
 are fully supported, and are implemented using database savepoints.
 


### PR DESCRIPTION
I wasn't able to find a way to properly use the transaction decorator when using with other decorators in the docs.
I thought it would be helpful to add this portion so others can also be aware they need to put the decorator right above the function signature without going into the code and finding out about it themselves.