### PR TITLE
Allow string indexing into Record

### DIFF
--- a/databases/interfaces.py
+++ b/databases/interfaces.py
@@ -73,3 +73,6 @@ class Record(Sequence):
     @property
     def _mapping(self) -> typing.Mapping:
         raise NotImplementedError()  # pragma: no cover
+
+    def __getitem__(self, key: typing.Union[str | int]) -> typing.Any:
+        raise NotImplementedError()  # pragma: no cover

--- a/databases/interfaces.py
+++ b/databases/interfaces.py
@@ -74,5 +74,5 @@ class Record(Sequence):
     def _mapping(self) -> typing.Mapping:
         raise NotImplementedError()  # pragma: no cover
 
-    def __getitem__(self, key: typing.Union[str | int]) -> typing.Any:
+    def __getitem__(self, key: typing.Any) -> typing.Any:
         raise NotImplementedError()  # pragma: no cover


### PR DESCRIPTION
The Record interface inherits from Sequence which only supports integer indexing. The Postgres backend supports string indexing into Records (https://github.com/encode/databases/blob/master/databases/backends/postgres.py#L135).  This PR updates the interface to reflect that.

At least on the Postgres backend __getitem__ deserializes some data types, so it's not equivalent to the _mapping property.