### PR TITLE
add mysql support for unix socket

### DIFF
--- a/databases/backends/mysql.py
+++ b/databases/backends/mysql.py
@@ -66,6 +66,7 @@ class MySQLBackend(DatabaseBackend):
         self._pool = await aiomysql.create_pool(
             host=self._database_url.hostname,
             port=self._database_url.port or 3306,
+            unix_socket=self._database_url.options.get('unix_sock'),
             user=self._database_url.username or getpass.getuser(),
             password=self._database_url.password,
             db=self._database_url.database,


### PR DESCRIPTION
Now that `databases` `URL` has a `unix_sock` param, use it for mysql connections.

See also the older #239.