### PR TITLE
Ensure __getattr__ matches __getitem__'s behaviour

### DIFF
--- a/databases/backends/postgres.py
+++ b/databases/backends/postgres.py
@@ -155,7 +155,7 @@ class Record(RecordInterface):
         return len(self._row)
 
     def __getattr__(self, name: str) -> typing.Any:
-        return self._mapping.get(name)
+        return self.__getitem__(name)
 
 
 class PostgresConnection(ConnectionBackend):


### PR DESCRIPTION
The `__getitem__` function does extra deserialisation that's not happening in __getattr__. As an example referencing a JSONB field with __getitem__ gets you a `dict` whereas `__getattr__` results in a `str`. This PR aligns their behaviour.