### PR TITLE
Fixes breaking changes in SQLAlchemy cursor

### DIFF
--- a/databases/backends/aiopg.py
+++ b/databases/backends/aiopg.py
@@ -221,6 +221,7 @@ class AiopgConnection(ConnectionBackend):
                 compiled._result_columns,
                 compiled._ordered_columns,
                 compiled._textual_ordered_columns,
+                compiled._ad_hoc_textual,
                 compiled._loose_column_name_matching,
             )
         else:

--- a/databases/backends/asyncmy.py
+++ b/databases/backends/asyncmy.py
@@ -211,6 +211,7 @@ class AsyncMyConnection(ConnectionBackend):
                 compiled._result_columns,
                 compiled._ordered_columns,
                 compiled._textual_ordered_columns,
+                compiled._ad_hoc_textual,
                 compiled._loose_column_name_matching,
             )
         else:

--- a/databases/backends/mysql.py
+++ b/databases/backends/mysql.py
@@ -211,6 +211,7 @@ class MySQLConnection(ConnectionBackend):
                 compiled._result_columns,
                 compiled._ordered_columns,
                 compiled._textual_ordered_columns,
+                compiled._ad_hoc_textual,
                 compiled._loose_column_name_matching,
             )
         else:

--- a/databases/backends/sqlite.py
+++ b/databases/backends/sqlite.py
@@ -185,6 +185,7 @@ class SQLiteConnection(ConnectionBackend):
                 compiled._result_columns,
                 compiled._ordered_columns,
                 compiled._textual_ordered_columns,
+                compiled._ad_hoc_textual,
                 compiled._loose_column_name_matching,
             )
 

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup(
     author_email="tom@tomchristie.com",
     packages=get_packages("databases"),
     package_data={"databases": ["py.typed"]},
-    install_requires=["sqlalchemy>=1.4,<=1.4.41"],
+    install_requires=["sqlalchemy>=1.4.42,<1.5"],
     extras_require={
         "postgresql": ["asyncpg"],
         "asyncpg": ["asyncpg"],


### PR DESCRIPTION
- fixes #512

SQLAlchemy 1.4.42 added a new property `ad_hoc_textual ` to cursor in https://github.com/sqlalchemy/sqlalchemy/commit/c9af2ebf5e5d288aea3a3a26bdf950e08ac4f927
and now expects it to be in `context.result_column_struct ` that is required to construct `CursorResultMetaData`

This pull request changes all database drivers to be in line with the change in SQLAlchemy repo