### PR TITLE
docs: Update sqlalchemy core tutorial link

### DIFF
--- a/docs/database_queries.md
+++ b/docs/database_queries.md
@@ -107,7 +107,7 @@ result = await database.fetch_one(query=query, values={"id": 1})
 Note that query arguments should follow the `:query_arg` style.
 
 [sqlalchemy-core]: https://docs.sqlalchemy.org/en/latest/core/
-[sqlalchemy-core-tutorial]: https://docs.sqlalchemy.org/en/latest/core/tutorial.html
+[sqlalchemy-core-tutorial]: https://docs.sqlalchemy.org/en/14/core/tutorial.html
 
 ## Query result
 


### PR DESCRIPTION
The current link in the docs (specifying the version "latest") now points to the docs for the SQLAlchemy 2.0 beta. This PR changes the link to strictly specify version 1.4.

It would also be possible to change the link to point to "stable" rather than "latest", however 1.4 seemed more appropriate as "stable" will likely point to 2.0 before this library migrates.

Cheers