### PR TITLE
Repetitive InterfaceError("(0, 'Not Connected')") Error in Nested Transactions.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,6 +20,7 @@ pytest==7.1.2
 pytest-cov==3.0.0
 starlette==0.20.4
 requests==2.28.1
+types-PyMySQL==1.0.19.1
 
 # Documentation
 mkdocs==1.3.1
@@ -29,3 +30,4 @@ mkautodoc==0.1.0
 # Packaging
 twine==4.0.1
 wheel==0.38.1
+


### PR DESCRIPTION
Dear Authors, 

I've been working on a project when I encountered the problem mentioned in the title, which occurs when nested transactions encounter a short period of database disconnection. 

I've reproduced the problem with a short [example code](https://github.com/encode/databases/files/10426956/example.txt).
(Please build a simple MySQL database, configure the example code to connect to it on line 8, and fetch arbitrary data from the database on line 27.)


I can consistently reproduce the problem by restarting the SQL server while the process enters a nested transaction( when the message "1:enter a transaction nest" prompts in the terminal).

The testing environment installed the following packages:
aiomysql==0.1.1
autopep8 @ file:///opt/conda/conda-bld/autopep8_1650463822033/work
certifi @ file:///croot/certifi_1671487769961/work/certifi
cffi==1.15.1
cryptography==39.0.0
databases==0.7.0
greenlet==2.0.1
pycodestyle @ file:///tmp/build/80754af9/pycodestyle_1636635402688/work
pycparser==2.21
pydantic==1.10.2
PyMySQL==1.0.2
SQLAlchemy==1.4.46
toml @ file:///tmp/build/80754af9/toml_1616166611790/work
typing_extensions==4.4.0

After diving into the problem, I found out the exception will occur while trying to start/begin a transaction in nested transactions. The transaction failed to start due to losing connection to the SQL server, however, the connection counter didn't adjust to the error. Therefore, I tried to fix the problem with additional exception handling. In addition, while proceeding with the __aexit__ function, the transaction would try to perform rollback while the SQL server remains disconnected. I've also attempted to skip the rollback process under such conditions. After the adjustments, the problem is resolved and the connection pool can successfully reconnect to the SQL server.