### PR TITLE
fix: incorrect concurrent usage of connection and transaction

### DIFF
--- a/databases/core.py
+++ b/databases/core.py
@@ -193,7 +193,7 @@ class Database:
         if self._global_connection is not None:
             return self._global_connection
 
-        connection = self._connection_contextvar.get(default=None)
+        connection = self._connection_contextvar.get(None)
         if connection is None:
             connection = Connection(self._backend)
             self._connection_contextvar.set(connection)
@@ -417,7 +417,7 @@ class Transaction:
 
     async def commit(self) -> None:
         connection = self._connection_callable()
-        transaction = self._transaction_contextvar.get(default=None)
+        transaction = self._transaction_contextvar.get(None)
         assert transaction is not None, "Transaction not found in current task"
         async with connection._transaction_lock:
             assert connection._transaction_stack[-1] is self
@@ -429,7 +429,7 @@ class Transaction:
 
     async def rollback(self) -> None:
         connection = self._connection_callable()
-        transaction = self._transaction_contextvar.get(default=None)
+        transaction = self._transaction_contextvar.get(None)
         assert transaction is not None, "Transaction not found in current task"
         async with connection._transaction_lock:
             assert connection._transaction_stack[-1] is self

--- a/databases/core.py
+++ b/databases/core.py
@@ -36,8 +36,8 @@ except ImportError:  # pragma: no cover
 logger = logging.getLogger("databases")
 
 # Connections are stored as task-local state, but care must be taken to ensure
-# that two database instances in the same task overwrite each other's connections.
-# For this reason, key comprises the database instance and the current task.
+# that two database instances in the same task do not overwrite each other's connections.
+# For this reason, the dict key comprises the database instance and the current task.
 _connection_contextmap: ContextVar[
     Dict[Tuple["Database", asyncio.Task], "Connection"]
 ] = ContextVar("databases:Connection")

--- a/databases/core.py
+++ b/databases/core.py
@@ -5,7 +5,7 @@ import logging
 import typing
 from contextvars import ContextVar
 from types import TracebackType
-from typing import Dict, Optional
+from typing import Dict
 from urllib.parse import SplitResult, parse_qsl, unquote, urlsplit
 
 from sqlalchemy import text
@@ -127,6 +127,7 @@ class Database:
             self._global_connection = None
         else:
             task = asyncio.current_task()
+            assert task is not None, "Not running in an asyncio task"
             connections = _get_connection_contextmap()
             if (self, task) in connections:
                 del connections[self, task]
@@ -204,6 +205,7 @@ class Database:
             return self._global_connection
 
         task = asyncio.current_task()
+        assert task is not None, "Not running in an asyncio task"
         connections = _get_connection_contextmap()
         if (self, task) not in connections:
             connections[self, task] = Connection(self._backend)

--- a/databases/core.py
+++ b/databases/core.py
@@ -5,7 +5,7 @@ import logging
 import typing
 from contextvars import ContextVar
 from types import TracebackType
-from typing import Dict
+from typing import Dict, Tuple
 from urllib.parse import SplitResult, parse_qsl, unquote, urlsplit
 
 from sqlalchemy import text
@@ -39,11 +39,11 @@ logger = logging.getLogger("databases")
 # that two database instances in the same task overwrite each other's connections.
 # For this reason, key comprises the database instance and the current task.
 _connection_contextmap: ContextVar[
-    Dict[tuple["Database", asyncio.Task], "Connection"]
+    Dict[Tuple["Database", asyncio.Task], "Connection"]
 ] = ContextVar("databases:Connection")
 
 
-def _get_connection_contextmap() -> Dict[tuple["Database", asyncio.Task], "Connection"]:
+def _get_connection_contextmap() -> Dict[Tuple["Database", asyncio.Task], "Connection"]:
     connections = _connection_contextmap.get(None)
     if connections is None:
         connections = {}

--- a/databases/core.py
+++ b/databases/core.py
@@ -63,7 +63,7 @@ class Database:
         self._backend = backend_cls(self.url, **self.options)
 
         # Connections are stored per asyncio task
-        self._connections: typing.Dict[typing.Optional[asyncio.Task], Connection] = {}
+        self._connections: typing.Dict[asyncio.Task, Connection] = {}
 
         # When `force_rollback=True` is used, we use a single global
         # connection, within a transaction that always rolls back.

--- a/databases/core.py
+++ b/databases/core.py
@@ -35,12 +35,12 @@ except ImportError:  # pragma: no cover
 
 logger = logging.getLogger("databases")
 
-_ACTIVE_CONNECTIONS: ContextVar[
-    typing.Optional[weakref.WeakKeyDictionary["Database", "Connection"]]
-] = ContextVar("databases:open_connections", default=None)
 
+_ACTIVE_CONNECTIONS: ContextVar[
+    typing.Optional["weakref.WeakKeyDictionary['Database', 'Connection']"]
+] = ContextVar("databases:open_connections", default=None)
 _ACTIVE_TRANSACTIONS: ContextVar[
-    typing.Optional[weakref.WeakKeyDictionary["Transaction", "TransactionBackend"]]
+    typing.Optional["weakref.WeakKeyDictionary['Transaction', 'TransactionBackend']"]
 ] = ContextVar("databases:open_transactions", default=None)
 
 

--- a/tests/test_databases.py
+++ b/tests/test_databases.py
@@ -2,12 +2,13 @@ import asyncio
 import datetime
 import decimal
 import functools
+import gc
 import itertools
 import os
 import re
-import gc
-from unittest.mock import MagicMock, patch
 from typing import MutableMapping
+from unittest.mock import MagicMock, patch
+
 import pytest
 import sqlalchemy
 

--- a/tests/test_databases.py
+++ b/tests/test_databases.py
@@ -2,10 +2,11 @@ import asyncio
 import datetime
 import decimal
 import functools
+import itertools
 import os
 import re
 from unittest.mock import MagicMock, patch
-import itertools
+
 import pytest
 import sqlalchemy
 


### PR DESCRIPTION
> [!NOTE]
> EDIT: This PR contains some back and forth on how _**databases**_ should handle concurrent connections across tasks. If you're looking into _**databases**_ concurrency model, it's worth taking a read through all of our comments. The specific issue with the `@Database.transaction` decorator was fixed, but it required digging into _and changing_ how connection state is tracked across `asyncio.Tasks` using `asyncio.ContextVars`

---

This commit should fix an issue with shared state with transactions.

The main issue is very well described by @circlingthesun here: https://github.com/encode/databases/issues/123#issuecomment-1028486810 - we also ran into this most reliably using locust to load test as well, but did find this issue a few times in normal usage. 

The big problem is that using the `@db.transaction` decorator creates a new `Databases.Transaction` instance that, when called creates a context manager for a transaction. The problem is that in concurrent frameworks, such as ASGI servers like starlette / fastapi, it's possible to have two concurrent tasks running. Since the Transaction instance is shared between tasks, it's `self` variable is comparable to shared global state, concurrent code can't trust that no race condition has occurred without some helper mechanism like a ContextVar.

Here's a mermaid diagram trying to show this: 
```mermaid
sequenceDiagram
    actor User1
    actor User2
    participant API
    participant TXN
    API->>TXN: (startup) @db.transaction creates new shared Transaction(...) for route
    User1->>API: (1): Request to API route creates new asyncio.Task(...)
    API->>TXN: (1): Transaction.__call__ assignes self._connection
    User2->>API: (2): Request to same API route creates new asyncio.Task(...)
    API->>TXN: (2): PROBLEM -- Transaction.__call__ obtains new Databases.Connection for this asyncio.Task,<br/> like above, but overwrites self._connection
    TXN->>API: (1): PROBLEM -- Transaction.__aexit__ uses self._connection of task (2)<br/>since it was not retrieved from a ContextVar
    API->>User1: (1): Responding here closes the transaction's _connection
    TXN->>API: (2): FAULT -- Transaction.__aexit__ expects to also close self._connection, <br/>but since it also tries to retrieve the connection from self._connection instead of the ContextVar,<br/>it retireves (1)'s already closed connection
    API->>User2: (2): FAULT -- Propigated exception results in 500 response code
```

All I've done with this PR is move the shared global state of `self._connection` and `self._transaction` into local or contextvars instead of instance variables.

Related issues are: #123 #134
Possibly related: #340
Related meta issue: #456 