### PR TITLE
Restore synchronous database drivers in test requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,8 +8,8 @@ aiosqlite==0.17.0
 asyncpg==0.26.0
 
 # Sync database drivers for standard tooling around setup/teardown/migrations.
-# psycopg2-binary==2.9.3
-# pymysql==1.0.2
+psycopg2-binary==2.9.3
+pymysql==1.0.2
 
 # Testing
 autoflake==1.4


### PR DESCRIPTION
Removed by accident in https://github.com/encode/databases/pull/561 — I think ~6 tests are being skipped because of it.