### PR TITLE
Fix flaky tests with in-memory SQLite databases

### DIFF
--- a/tests/test_databases.py
+++ b/tests/test_databases.py
@@ -1549,7 +1549,10 @@ async def test_mapping_property_interface(database_url):
 
 @async_adapter
 async def test_should_not_maintain_ref_when_no_cache_param():
-    async with Database("sqlite:///file::memory:", uri=True) as database:
+    async with Database(
+        "sqlite:///file::memory:test_should_not_maintain_ref_when_no_cache_param",
+        uri=True,
+    ) as database:
         query = sqlalchemy.schema.CreateTable(notes)
         await database.execute(query)
 
@@ -1561,7 +1564,10 @@ async def test_should_not_maintain_ref_when_no_cache_param():
 
 @async_adapter
 async def test_should_maintain_ref_when_cache_param():
-    async with Database("sqlite:///file::memory:?cache=shared", uri=True) as database:
+    async with Database(
+        "sqlite:///file::memory:test_should_maintain_ref_when_cache_param?cache=shared",
+        uri=True,
+    ) as database:
         query = sqlalchemy.schema.CreateTable(notes)
         await database.execute(query)
 
@@ -1577,7 +1583,10 @@ async def test_should_maintain_ref_when_cache_param():
 
 @async_adapter
 async def test_should_remove_ref_on_disconnect():
-    async with Database("sqlite:///file::memory:?cache=shared", uri=True) as database:
+    async with Database(
+        "sqlite:///file::memory:test_should_remove_ref_on_disconnect?cache=shared",
+        uri=True,
+    ) as database:
         query = sqlalchemy.schema.CreateTable(notes)
         await database.execute(query)
 
@@ -1588,7 +1597,10 @@ async def test_should_remove_ref_on_disconnect():
     # Run garbage collection to reset the database if we dropped the reference
     gc.collect()
 
-    async with Database("sqlite:///file::memory:?cache=shared", uri=True) as database:
+    async with Database(
+        "sqlite:///file::memory:test_should_remove_ref_on_disconnect?cache=shared",
+        uri=True,
+    ) as database:
         query = notes.select()
         with pytest.raises(sqlite3.OperationalError):
             await database.fetch_all(query=query)

--- a/tests/test_databases.py
+++ b/tests/test_databases.py
@@ -1585,6 +1585,9 @@ async def test_should_remove_ref_on_disconnect():
         values = {"text": "example1", "completed": True}
         await database.execute(query, values)
 
+    # Run garbage collection to reset the database if we dropped the reference
+    gc.collect()
+
     async with Database("sqlite:///file::memory:?cache=shared", uri=True) as database:
         query = notes.select()
         with pytest.raises(sqlite3.OperationalError):

--- a/tests/test_databases.py
+++ b/tests/test_databases.py
@@ -115,6 +115,9 @@ def create_test_database():
         engine = sqlalchemy.create_engine(url)
         metadata.drop_all(engine)
 
+    # Run garbage collection to ensure any in-memory databases are dropped
+    gc.collect()
+
 
 def async_adapter(wrapped_func):
     """
@@ -1550,7 +1553,7 @@ async def test_mapping_property_interface(database_url):
 @async_adapter
 async def test_should_not_maintain_ref_when_no_cache_param():
     async with Database(
-        "sqlite:///file::memory:test_should_not_maintain_ref_when_no_cache_param",
+        "sqlite:///file::memory:",
         uri=True,
     ) as database:
         query = sqlalchemy.schema.CreateTable(notes)
@@ -1565,7 +1568,7 @@ async def test_should_not_maintain_ref_when_no_cache_param():
 @async_adapter
 async def test_should_maintain_ref_when_cache_param():
     async with Database(
-        "sqlite:///file::memory:test_should_maintain_ref_when_cache_param?cache=shared",
+        "sqlite:///file::memory:?cache=shared",
         uri=True,
     ) as database:
         query = sqlalchemy.schema.CreateTable(notes)
@@ -1584,7 +1587,7 @@ async def test_should_maintain_ref_when_cache_param():
 @async_adapter
 async def test_should_remove_ref_on_disconnect():
     async with Database(
-        "sqlite:///file::memory:test_should_remove_ref_on_disconnect?cache=shared",
+        "sqlite:///file::memory:?cache=shared",
         uri=True,
     ) as database:
         query = sqlalchemy.schema.CreateTable(notes)
@@ -1598,7 +1601,7 @@ async def test_should_remove_ref_on_disconnect():
     gc.collect()
 
     async with Database(
-        "sqlite:///file::memory:test_should_remove_ref_on_disconnect?cache=shared",
+        "sqlite:///file::memory:?cache=shared",
         uri=True,
     ) as database:
         query = notes.select()


### PR DESCRIPTION
Closes https://github.com/encode/databases/issues/567 by ensuring garbage collection is run consistently to prevent flakes where the in-memory SQLite database is not dropped.