### PR TITLE
enabler(backends): allow ssl string parameters in PostgreSQL URL

### DIFF
--- a/databases/backends/postgres.py
+++ b/databases/backends/postgres.py
@@ -55,7 +55,8 @@ class PostgresBackend(DatabaseBackend):
         if max_size is not None:
             kwargs["max_size"] = int(max_size)
         if ssl is not None:
-            kwargs["ssl"] = {"true": True, "false": False}[ssl.lower()]
+            ssl = ssl.lower()
+            kwargs["ssl"] = {"true": True, "false": False}.get(ssl, ssl)
 
         kwargs.update(self._options)
 

--- a/tests/test_connection_options.py
+++ b/tests/test_connection_options.py
@@ -46,10 +46,22 @@ def test_postgres_ssl():
     assert kwargs == {"ssl": True}
 
 
+def test_postgres_ssl_verify_full():
+    backend = PostgresBackend("postgres://localhost/database?ssl=verify-full")
+    kwargs = backend._get_connection_kwargs()
+    assert kwargs == {"ssl": "verify-full"}
+
+
 def test_postgres_explicit_ssl():
     backend = PostgresBackend("postgres://localhost/database", ssl=True)
     kwargs = backend._get_connection_kwargs()
     assert kwargs == {"ssl": True}
+
+
+def test_postgres_explicit_ssl_verify_full():
+    backend = PostgresBackend("postgres://localhost/database", ssl="verify-full")
+    kwargs = backend._get_connection_kwargs()
+    assert kwargs == {"ssl": "verify-full"}
 
 
 def test_postgres_no_extra_options():


### PR DESCRIPTION
Closes #575.

The underlying library asyncpg accepts string values in the ssl parameter. The old code only accepted the values true and false, which are converted to boolean.