### PR TITLE
Fix some column types being parsed twice

### DIFF
--- a/databases/backends/common/records.py
+++ b/databases/backends/common/records.py
@@ -1,6 +1,6 @@
 import enum
 import typing
-from datetime import date, datetime
+from datetime import date, datetime, time
 
 from sqlalchemy.engine.interfaces import Dialect
 from sqlalchemy.engine.row import Row as SQLRow
@@ -67,7 +67,9 @@ class Record(RecordInterface):
             if isinstance(datatype, JSON):
                 return raw
 
-        if processor is not None and not isinstance(raw, (datetime, date, enum.Enum)):
+        if processor is not None and not isinstance(
+            raw, (datetime, date, time, enum.Enum)
+        ):
             return processor(raw)
         return raw
 

--- a/databases/backends/common/records.py
+++ b/databases/backends/common/records.py
@@ -1,4 +1,4 @@
-import json
+import enum
 import typing
 from datetime import date, datetime
 
@@ -6,6 +6,7 @@ from sqlalchemy.engine.interfaces import Dialect
 from sqlalchemy.engine.row import Row as SQLRow
 from sqlalchemy.sql.compiler import _CompileLabel
 from sqlalchemy.sql.schema import Column
+from sqlalchemy.sql.sqltypes import JSON
 from sqlalchemy.types import TypeEngine
 
 from databases.interfaces import Record as RecordInterface
@@ -63,10 +64,10 @@ class Record(RecordInterface):
         processor = datatype._cached_result_processor(self._dialect, None)
 
         if self._dialect.name not in DIALECT_EXCLUDE:
-            if isinstance(raw, dict):
-                raw = json.dumps(raw)
+            if isinstance(datatype, JSON):
+                return raw
 
-        if processor is not None and (not isinstance(raw, (datetime, date))):
+        if processor is not None and not isinstance(raw, (datetime, date, enum.Enum)):
             return processor(raw)
         return raw
 

--- a/databases/backends/common/records.py
+++ b/databases/backends/common/records.py
@@ -63,14 +63,10 @@ class Record(RecordInterface):
         raw = self._row[idx]
         processor = datatype._cached_result_processor(self._dialect, None)
 
-        if self._dialect.name not in DIALECT_EXCLUDE:
-            if isinstance(datatype, JSON):
-                return raw
+        if self._dialect.name in DIALECT_EXCLUDE:
+            if processor is not None and isinstance(raw, (int, str, float)):
+                return processor(raw)
 
-        if processor is not None and not isinstance(
-            raw, (datetime, date, time, enum.Enum)
-        ):
-            return processor(raw)
         return raw
 
     def __iter__(self) -> typing.Iterator:

--- a/tests/test_databases.py
+++ b/tests/test_databases.py
@@ -1,6 +1,7 @@
 import asyncio
 import datetime
 import decimal
+import enum
 import functools
 import gc
 import itertools
@@ -53,6 +54,30 @@ articles = sqlalchemy.Table(
     sqlalchemy.Column("id", sqlalchemy.Integer, primary_key=True),
     sqlalchemy.Column("title", sqlalchemy.String(length=100)),
     sqlalchemy.Column("published", sqlalchemy.DateTime),
+)
+
+
+class TshirtSize(enum.Enum):
+    SMALL = "SMALL"
+    MEDIUM = "MEDIUM"
+    LARGE = "LARGE"
+    XL = "XL"
+
+
+class TshirtColor(enum.Enum):
+    BLUE = 0
+    GREEN = 1
+    YELLOW = 2
+    RED = 3
+
+
+# Used to test Enum
+tshirt_size = sqlalchemy.Table(
+    "tshirt_size",
+    metadata,
+    sqlalchemy.Column("id", sqlalchemy.Integer, primary_key=True),
+    sqlalchemy.Column("size", sqlalchemy.Enum(TshirtSize)),
+    sqlalchemy.Column("color", sqlalchemy.Enum(TshirtColor))
 )
 
 # Used to test JSON
@@ -957,7 +982,32 @@ async def test_decimal_field(database_url):
 
 @pytest.mark.parametrize("database_url", DATABASE_URLS)
 @async_adapter
-async def test_json_field(database_url):
+async def test_enum_field(database_url):
+    """
+    Test JSON columns, to ensure correct cross-database support.
+    """
+
+    async with Database(database_url) as database:
+        async with database.transaction(force_rollback=True):
+            # execute()
+            size = TshirtSize.SMALL
+            color = TshirtColor.GREEN
+            values = {"size": size, "color": color}
+            query = tshirt_size.insert()
+            await database.execute(query, values)
+
+            # fetch_all()
+            query = tshirt_size.select()
+            results = await database.fetch_all(query=query)
+
+            assert len(results) == 1
+            assert results[0]["size"] == size
+            assert results[0]["color"] == color
+
+
+@pytest.mark.parametrize("database_url", DATABASE_URLS)
+@async_adapter
+async def test_json_dict_field(database_url):
     """
     Test JSON columns, to ensure correct cross-database support.
     """
@@ -976,6 +1026,29 @@ async def test_json_field(database_url):
 
             assert len(results) == 1
             assert results[0]["data"] == {"text": "hello", "boolean": True, "int": 1}
+
+
+@pytest.mark.parametrize("database_url", DATABASE_URLS)
+@async_adapter
+async def test_json_list_field(database_url):
+    """
+    Test JSON columns, to ensure correct cross-database support.
+    """
+
+    async with Database(database_url) as database:
+        async with database.transaction(force_rollback=True):
+            # execute()
+            data = ['lemon', 'raspberry', 'lime', 'pumice']
+            values = {"data": data}
+            query = session.insert()
+            await database.execute(query, values)
+
+            # fetch_all()
+            query = session.select()
+            results = await database.fetch_all(query=query)
+
+            assert len(results) == 1
+            assert results[0]["data"] == ['lemon', 'raspberry', 'lime', 'pumice']
 
 
 @pytest.mark.parametrize("database_url", DATABASE_URLS)

--- a/tests/test_databases.py
+++ b/tests/test_databases.py
@@ -77,7 +77,7 @@ tshirt_size = sqlalchemy.Table(
     metadata,
     sqlalchemy.Column("id", sqlalchemy.Integer, primary_key=True),
     sqlalchemy.Column("size", sqlalchemy.Enum(TshirtSize)),
-    sqlalchemy.Column("color", sqlalchemy.Enum(TshirtColor))
+    sqlalchemy.Column("color", sqlalchemy.Enum(TshirtColor)),
 )
 
 # Used to test JSON
@@ -1038,7 +1038,7 @@ async def test_json_list_field(database_url):
     async with Database(database_url) as database:
         async with database.transaction(force_rollback=True):
             # execute()
-            data = ['lemon', 'raspberry', 'lime', 'pumice']
+            data = ["lemon", "raspberry", "lime", "pumice"]
             values = {"data": data}
             query = session.insert()
             await database.execute(query, values)
@@ -1048,7 +1048,7 @@ async def test_json_list_field(database_url):
             results = await database.fetch_all(query=query)
 
             assert len(results) == 1
-            assert results[0]["data"] == ['lemon', 'raspberry', 'lime', 'pumice']
+            assert results[0]["data"] == ["lemon", "raspberry", "lime", "pumice"]
 
 
 @pytest.mark.parametrize("database_url", DATABASE_URLS)


### PR DESCRIPTION
After the SQLAlchemy 2.0 fixes, ormar's test suite highlighted a problem with JSON and enum types getting parsed from the database a second time. This should fix the problem. I'm not sure if there are any other data types affected at the moment, it should hopefully be just these two. I've also added appropriate tests for these data types.

Let me know if I need to change anything, thanks!